### PR TITLE
Remove RegionId field from StatUnitSearchView. Update mappings.

### DIFF
--- a/src/nscreg.Data/Entities/StatUnitSearchView.cs
+++ b/src/nscreg.Data/Entities/StatUnitSearchView.cs
@@ -12,7 +12,6 @@ namespace nscreg.Data.Entities
         public string StatId { get; set; }
         public string TaxRegId { get; set; }
         public string ExternalId { get; set; }
-        public int? RegionId { get; set; }
         public int? ActualAddressRegionId { get; set; }
         public decimal? Turnover { get; set; }
         public int? SectorCodeId { get; set; }

--- a/src/nscreg.Server.Common/AutoMapperProfile.cs
+++ b/src/nscreg.Server.Common/AutoMapperProfile.cs
@@ -160,11 +160,11 @@ namespace nscreg.Server.Common
                 .ForMember(x => x.Activities, opt => opt.Ignore());
 
             CreateMap<StatUnitSearchView, ElasticStatUnit>()
-                .ForMember(d => d.RegionIds, opt => opt.MapFrom(s => s.RegionId != null ? new List<int> { (int)s.RegionId } : new List<int>()));
+                .ForMember(d => d.RegionIds, opt => opt.MapFrom(s => s.ActualAddressRegionId != null ? new List<int> { (int)s.ActualAddressRegionId } : new List<int>()));
 
             CreateMap<IStatisticalUnit, ElasticStatUnit>()
                 .ForMember(d => d.LiqDate, opt => opt.MapFrom(s => (s is EnterpriseGroup) ? (s as EnterpriseGroup).LiqDateEnd : (s as StatisticalUnit).LiqDate))
-                .ForMember(d => d.RegionId, opt => opt.MapFrom(s => s.ActualAddress.RegionId))
+                .ForMember(d => d.ActualAddressRegionId, opt => opt.MapFrom(s => s.ActualAddress.RegionId))
                 .ForMember(d => d.SectorCodeId, opt => opt.MapFrom(s => s.InstSectorCodeId))
                 .ForMember(d => d.ActualAddressPart1, opt => opt.MapFrom(s => s.ActualAddress.AddressPart1))
                 .ForMember(d => d.ActualAddressPart2, opt => opt.MapFrom(s => s.ActualAddress.AddressPart2))

--- a/src/nscreg.Server.Common/Services/StatUnit/ElasticService.cs
+++ b/src/nscreg.Server.Common/Services/StatUnit/ElasticService.cs
@@ -317,8 +317,7 @@ namespace nscreg.Server.Common.Services.StatUnit
             {
                 int regionId = filter.RegionId.Value;
                 mustQueries.Add(m =>
-                    m.Term(p => p.Field(f => f.ActualAddressRegionId).Value(regionId))
-                     || m.Term(p => p.Field(f => f.ActualAddressRegionId).Value(regionId)));
+                    m.Term(p => p.Field(f => f.RegionIds).Value(regionId)));
             }
 
             Func<SearchDescriptor<ElasticStatUnit>, ISearchRequest> searchFunc;

--- a/src/nscreg.Server.Common/Services/StatUnit/ElasticService.cs
+++ b/src/nscreg.Server.Common/Services/StatUnit/ElasticService.cs
@@ -317,7 +317,7 @@ namespace nscreg.Server.Common.Services.StatUnit
             {
                 int regionId = filter.RegionId.Value;
                 mustQueries.Add(m =>
-                    m.Term(p => p.Field(f => f.RegionId).Value(regionId))
+                    m.Term(p => p.Field(f => f.ActualAddressRegionId).Value(regionId))
                      || m.Term(p => p.Field(f => f.ActualAddressRegionId).Value(regionId)));
             }
 

--- a/src/nscreg.Server.Common/Services/StatUnit/SearchService.cs
+++ b/src/nscreg.Server.Common/Services/StatUnit/SearchService.cs
@@ -76,7 +76,7 @@ namespace nscreg.Server.Common.Services.StatUnit
 
             var finalIds = units.Where(x => x.UnitType != StatUnitTypes.EnterpriseGroup)
                 .Select(x => x.RegId).ToList();
-            var finalRegionIds = units.Select(x => x.ActualAddressRegionId ?? x.RegionId).ToList();
+            var finalRegionIds = units.Select(x => x.ActualAddressRegionId ?? x.ActualAddressRegionId).ToList();
 
             var unitsToPersonNames = await GetUnitsToPersonNamesByUnitIds(finalIds);
 
@@ -89,10 +89,10 @@ namespace nscreg.Server.Common.Services.StatUnit
             var result = units
                 .Select(x => new SearchViewAdapterModel(x, unitsToPersonNames[x.RegId],
                     unitsToMainActivities[x.RegId],
-                    regions.GetValueOrDefault(x.ActualAddressRegionId ?? x.RegionId), _mapper))
+                    regions.GetValueOrDefault(x.ActualAddressRegionId ?? x.ActualAddressRegionId), _mapper))
                 .Select(x => SearchItemVm.Create(x, x.UnitType,
                     permissions.GetReadablePropNames(), !isAdmin &&
-                    !helper.IsRegionOrActivityContains(userId, x.RegionId != null ? new List<int> { (int)x.RegionId } : new List<int>(), unitsToMainActivities[x.RegId].Select(z => z.Id).ToList())));
+                    !helper.IsRegionOrActivityContains(userId, x.ActualAddressRegionId != null ? new List<int> { (int)x.ActualAddressRegionId } : new List<int>(), unitsToMainActivities[x.RegId].Select(z => z.Id).ToList())));
 
             var viewModel = SearchVm.Create(result, totalCount);
             return viewModel;

--- a/src/nscreg.Server.Common/Services/StatUnit/SearchService.cs
+++ b/src/nscreg.Server.Common/Services/StatUnit/SearchService.cs
@@ -76,7 +76,7 @@ namespace nscreg.Server.Common.Services.StatUnit
 
             var finalIds = units.Where(x => x.UnitType != StatUnitTypes.EnterpriseGroup)
                 .Select(x => x.RegId).ToList();
-            var finalRegionIds = units.Select(x => x.ActualAddressRegionId ?? x.ActualAddressRegionId).ToList();
+            var finalRegionIds = units.Select(x => x.ActualAddressRegionId).ToList();
 
             var unitsToPersonNames = await GetUnitsToPersonNamesByUnitIds(finalIds);
 


### PR DESCRIPTION
Remove RegionId field from StatUnitSearchView since we don't use this field anymore (since we removed AddressId/AsRegistered). Update mappings to use ActualAddressRegionId instead.