### PR TITLE
[ui] Simplify prop type definition in CategoryStandardFormProps

### DIFF
--- a/app/src/app/getting-started/activity-standard/_components/CategoryStandardForm.tsx
+++ b/app/src/app/getting-started/activity-standard/_components/CategoryStandardForm.tsx
@@ -7,10 +7,11 @@ import {Form, FormControl, FormField, FormItem, FormLabel, FormMessage,} from "@
 import {useForm} from "react-hook-form";
 import {setCategoryStandard} from "@/app/getting-started/activity-standard/actions";
 import Link from "next/link";
+import {Tables} from "@/lib/database.types";
 
 interface CategoryStandardFormProps {
-  readonly standards: { id: number, name: string }[] | null
-  readonly settings: { id: number, activity_category_standard: { id: number, name: string } | null }[] | null
+  readonly standards: Tables<'activity_category_standard'>[] | null
+  readonly settings: Tables<'settings'>[] | null
 }
 
 const FormSchema = z.object({
@@ -25,7 +26,7 @@ export default function CategoryStandardForm({standards, settings}: CategoryStan
   const form = useForm<z.infer<typeof FormSchema>>({
     resolver: zodResolver(FormSchema),
     defaultValues: {
-      activity_category_standard_id: settings?.[0]?.activity_category_standard?.id
+      activity_category_standard_id: settings?.[0]?.activity_category_standard_id
     }
   })
 

--- a/app/src/app/getting-started/activity-standard/page.tsx
+++ b/app/src/app/getting-started/activity-standard/page.tsx
@@ -7,10 +7,10 @@ export default async function ActivityStandardPage() {
     const client = createClient()
 
     const {data: standards} = await client.from('activity_category_standard')
-        .select('id, name')
+        .select()
 
     const {data: settings} = await client.from('settings')
-        .select('id, activity_category_standard(id,name)')
+        .select()
 
     return <section className="space-y-8">
         <h1 className="text-xl text-center">Select Activity Category Standard</h1>


### PR DESCRIPTION
By using the Type Shorthands we avoid redefining supabase response types.

[See Supabase documentation for more information](https://supabase.com/docs/guides/api/rest/generating-types#type-shorthands)