### PR TITLE
Add new page for uploading custom activity category codes

### DIFF
--- a/app/src/app/getting-started/upload-custom-activity-standard-codes/UploadCustomActivitiesForm.tsx
+++ b/app/src/app/getting-started/upload-custom-activity-standard-codes/UploadCustomActivitiesForm.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import {useFormState} from "react-dom";
+import {Button, buttonVariants} from "@/components/ui/button";
+import {Label} from "@/components/ui/label";
+import {Input} from "@/components/ui/input";
+import Link from "next/link";
+import React from "react";
+import {ErrorBox} from "@/components/ErrorBox";
+import {uploadCustomActivityCodes} from "@/app/getting-started/upload-custom-activity-standard-codes/actions";
+
+const initialState: { error: string | null } = {
+  error: null
+}
+
+export default function UploadCustomActivitiesForm() {
+  const [state, formAction] = useFormState(uploadCustomActivityCodes, initialState)
+
+  return (
+    <form action={formAction} className="space-y-6 bg-green-100 p-6">
+      <Label className="block" htmlFor="custom-activity-categories-file">Select Custom Activity Categories file:</Label>
+      <Input required id="custom-activity-categories-file" type="file" name="custom_activity_category_codes"/>
+      {
+        state.error ? (
+          <ErrorBox>
+            <span>{state.error}</span>
+          </ErrorBox>
+        ) : null
+      }
+      <div className="space-x-3">
+        <Button type="submit">Upload</Button>
+        <Link href="/getting-started/upload-legal-units" className={buttonVariants({variant: 'outline'})}>Skip</Link>
+      </div>
+    </form>
+  )
+}

--- a/app/src/app/getting-started/upload-custom-activity-standard-codes/actions.ts
+++ b/app/src/app/getting-started/upload-custom-activity-standard-codes/actions.ts
@@ -1,0 +1,31 @@
+"use server";
+import {redirect, RedirectType} from "next/navigation";
+import {setupAuthorizedFetchFn} from "@/lib/supabase/request-helper";
+
+export async function uploadCustomActivityCodes(formData: FormData) {
+  "use server";
+
+  try {
+    const file = formData.get('custom_activity_category_codes') as File
+    const authFetch = setupAuthorizedFetchFn()
+    const response = await authFetch(`${process.env.SUPABASE_URL}/rest/v1/activity_category_available_custom`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'text/csv'
+      },
+      body: file
+    })
+
+    if (!response.ok) {
+      const data = await response.json()
+      console.error(`failed to upload custom activity category standards with status ${response.status} ${response.statusText}`)
+      console.error(data)
+      return {error: data.message}
+    }
+
+  } catch (e) {
+    return {error: 'failed to upload custom activity category standards'}
+  }
+
+  return redirect('/getting-started/upload-legal-units', RedirectType.push)
+}

--- a/app/src/app/getting-started/upload-custom-activity-standard-codes/actions.ts
+++ b/app/src/app/getting-started/upload-custom-activity-standard-codes/actions.ts
@@ -2,7 +2,11 @@
 import {redirect, RedirectType} from "next/navigation";
 import {setupAuthorizedFetchFn} from "@/lib/supabase/request-helper";
 
-export async function uploadCustomActivityCodes(formData: FormData) {
+interface State {
+  error: string | null
+}
+
+export async function uploadCustomActivityCodes(_prevState: State, formData: FormData): Promise<State> {
   "use server";
 
   try {

--- a/app/src/app/getting-started/upload-custom-activity-standard-codes/page.tsx
+++ b/app/src/app/getting-started/upload-custom-activity-standard-codes/page.tsx
@@ -1,0 +1,41 @@
+import {Label} from "@/components/ui/label";
+import {Input} from "@/components/ui/input";
+import {Button, buttonVariants} from "@/components/ui/button";
+import React from "react";
+import Link from "next/link";
+import {InfoBox} from "@/components/InfoBox";
+import {createClient} from "@/lib/supabase/server";
+import {uploadCustomActivityCodes} from "@/app/getting-started/upload-custom-activity-standard-codes/actions";
+
+export default async function UploadCustomActivityCategoryCodesPage() {
+  const client = createClient()
+  const {count} = await client.from('activity_category_available_custom').select('*', {count: 'exact', head: true})
+  return (
+    <section className="space-y-8">
+      <h1 className="text-xl text-center">Upload Custom Activity Category Standard Codes</h1>
+      <p>
+        Upload a CSV file containing the custom activity category standard codes you want to use in your analysis.
+      </p>
+
+      {
+        count && count > 0 ? (
+          <InfoBox>
+            <p>
+              There are already {count} custom activity category codes defined.
+            </p>
+          </InfoBox>
+        ) : null
+      }
+
+      <form action={uploadCustomActivityCodes} className="space-y-6 bg-green-100 p-6">
+        <Label className="block" htmlFor="custom-activity-categories-file">Select Custom Activity Categories
+          file:</Label>
+        <Input required id="custom-activity-categories-file" type="file" name="custom_activity_category_codes"/>
+        <div className="space-x-3">
+          <Button type="submit">Upload</Button>
+          <Link href="/getting-started/upload-legal-units" className={buttonVariants({variant: 'outline'})}>Skip</Link>
+        </div>
+      </form>
+    </section>
+  )
+}

--- a/app/src/app/getting-started/upload-custom-activity-standard-codes/page.tsx
+++ b/app/src/app/getting-started/upload-custom-activity-standard-codes/page.tsx
@@ -1,11 +1,7 @@
-import {Label} from "@/components/ui/label";
-import {Input} from "@/components/ui/input";
-import {Button, buttonVariants} from "@/components/ui/button";
 import React from "react";
-import Link from "next/link";
 import {InfoBox} from "@/components/InfoBox";
 import {createClient} from "@/lib/supabase/server";
-import {uploadCustomActivityCodes} from "@/app/getting-started/upload-custom-activity-standard-codes/actions";
+import UploadCustomActivitiesForm from "@/app/getting-started/upload-custom-activity-standard-codes/UploadCustomActivitiesForm";
 
 export default async function UploadCustomActivityCategoryCodesPage() {
   const client = createClient()
@@ -26,16 +22,7 @@ export default async function UploadCustomActivityCategoryCodesPage() {
           </InfoBox>
         ) : null
       }
-
-      <form action={uploadCustomActivityCodes} className="space-y-6 bg-green-100 p-6">
-        <Label className="block" htmlFor="custom-activity-categories-file">Select Custom Activity Categories
-          file:</Label>
-        <Input required id="custom-activity-categories-file" type="file" name="custom_activity_category_codes"/>
-        <div className="space-x-3">
-          <Button type="submit">Upload</Button>
-          <Link href="/getting-started/upload-legal-units" className={buttonVariants({variant: 'outline'})}>Skip</Link>
-        </div>
-      </form>
+      <UploadCustomActivitiesForm/>
     </section>
   )
 }

--- a/app/src/app/getting-started/upload-legal-units/UploadLegalUnitsForm.tsx
+++ b/app/src/app/getting-started/upload-legal-units/UploadLegalUnitsForm.tsx
@@ -7,7 +7,7 @@ import {Label} from "@/components/ui/label";
 import {Input} from "@/components/ui/input";
 import Link from "next/link";
 import React from "react";
-import {AlertCircle} from "lucide-react";
+import {ErrorBox} from "@/components/ErrorBox";
 
 const initialState: { error: string | null } = {
   error: null
@@ -22,12 +22,9 @@ export default function UploadLegalUnitsForm() {
       <Input required id="legal-units-file" type="file" name="legal_units"/>
       {
         state.error ? (
-          <div className="text-sm flex space-x-4 items-center p-3 bg-red-100">
-            <div>
-              <AlertCircle size={32} color="red"/>
-            </div>
-            <span className="text-red-500 font-semibold">{state.error}</span>
-          </div>
+          <ErrorBox>
+            <span>{state.error}</span>
+          </ErrorBox>
         ) : null
       }
       <div className="space-x-3">

--- a/app/src/app/getting-started/upload-legal-units/UploadLegalUnitsForm.tsx
+++ b/app/src/app/getting-started/upload-legal-units/UploadLegalUnitsForm.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import {uploadLegalUnits} from "@/app/getting-started/upload-legal-units/actions";
+import {useFormState} from "react-dom";
+import {Button, buttonVariants} from "@/components/ui/button";
+import {Label} from "@/components/ui/label";
+import {Input} from "@/components/ui/input";
+import Link from "next/link";
+import React from "react";
+import {AlertCircle} from "lucide-react";
+
+const initialState: { error: string | null } = {
+  error: null
+}
+
+export default function UploadLegalUnitsForm() {
+  const [state, formAction] = useFormState(uploadLegalUnits, initialState)
+
+  return (
+    <form action={formAction} className="space-y-6 bg-green-100 p-6">
+      <Label className="block" htmlFor="legal-units-file">Select Legal Units file:</Label>
+      <Input required id="legal-units-file" type="file" name="legal_units"/>
+      {
+        state.error ? (
+          <div className="text-sm flex space-x-4 items-center p-3 bg-red-100">
+            <div>
+              <AlertCircle size={32} color="red"/>
+            </div>
+            <span className="text-red-500 font-semibold">{state.error}</span>
+          </div>
+        ) : null
+      }
+      <div className="space-x-3">
+        <Button type="submit">Upload</Button>
+        <Link href="/getting-started/summary" className={buttonVariants({variant: 'outline'})}>Skip</Link>
+      </div>
+    </form>
+  )
+}

--- a/app/src/app/getting-started/upload-legal-units/actions.ts
+++ b/app/src/app/getting-started/upload-legal-units/actions.ts
@@ -2,7 +2,11 @@
 import {redirect, RedirectType} from "next/navigation";
 import {setupAuthorizedFetchFn} from "@/lib/supabase/request-helper";
 
-export async function uploadLegalUnits(_prevState: { error: string | null }, formData: FormData) {
+interface State {
+  error: string | null
+}
+
+export async function uploadLegalUnits(_prevState: State, formData: FormData): Promise<State> {
   "use server";
 
   try {

--- a/app/src/app/getting-started/upload-legal-units/actions.ts
+++ b/app/src/app/getting-started/upload-legal-units/actions.ts
@@ -2,11 +2,11 @@
 import {redirect, RedirectType} from "next/navigation";
 import {setupAuthorizedFetchFn} from "@/lib/supabase/request-helper";
 
-export async function uploadLegalUnits(formData: FormData) {
+export async function uploadLegalUnits(_prevState: { error: string | null }, formData: FormData) {
   "use server";
 
   try {
-    const file = formData.get('regions') as File
+    const file = formData.get('legal_units') as File
     const authFetch = setupAuthorizedFetchFn()
     const response = await authFetch(`${process.env.SUPABASE_URL}/rest/v1/legal_unit_region_activity_category_stats_current`, {
       method: 'POST',
@@ -20,7 +20,7 @@ export async function uploadLegalUnits(formData: FormData) {
       const data = await response.json()
       console.error(`legal units upload failed with status ${response.status} ${response.statusText}`)
       console.error(data)
-      return {error: data.message}
+      return {error: data.message.replace(/,/g, ', ')}
     }
 
   } catch (e) {

--- a/app/src/app/getting-started/upload-legal-units/page.tsx
+++ b/app/src/app/getting-started/upload-legal-units/page.tsx
@@ -1,14 +1,10 @@
-import {Label} from "@/components/ui/label";
-import {Input} from "@/components/ui/input";
-import {Button, buttonVariants} from "@/components/ui/button";
 import {Accordion, AccordionContent, AccordionItem, AccordionTrigger} from "@/components/ui/accordion";
-import {uploadLegalUnits} from "@/app/getting-started/upload-legal-units/actions";
 import React from "react";
-import Link from "next/link";
 import {InfoBox} from "@/components/InfoBox";
 import {createClient} from "@/lib/supabase/server";
+import UploadLegalUnitsForm from "@/app/getting-started/upload-legal-units/UploadLegalUnitsForm";
 
-export default async function UploadRegionsPage() {
+export default async function UploadLegalUnitsPage() {
   const client = createClient()
   const {count} = await client.from('legal_unit').select('*', {count: 'exact', head: true})
   return (
@@ -28,14 +24,7 @@ export default async function UploadRegionsPage() {
         ) : null
       }
 
-      <form action={uploadLegalUnits} className="space-y-6 bg-green-100 p-6">
-        <Label className="block" htmlFor="regions-file">Select Legal Units file:</Label>
-        <Input required id="regions-file" type="file" name="regions"/>
-        <div className="space-x-3">
-          <Button type="submit">Upload</Button>
-          <Link href="/getting-started/summary" className={buttonVariants({variant: 'outline'})}>Skip</Link>
-        </div>
-      </form>
+      <UploadLegalUnitsForm />
 
       <Accordion type="single" collapsible>
         <AccordionItem value="Legal Unit">

--- a/app/src/app/getting-started/upload-legal-units/page.tsx
+++ b/app/src/app/getting-started/upload-legal-units/page.tsx
@@ -22,7 +22,7 @@ export default async function UploadRegionsPage() {
         count && count > 0 ? (
           <InfoBox>
             <p>
-              There are already {count} legal units defined. You may skip this step.
+              There are already {count} legal units defined.
             </p>
           </InfoBox>
         ) : null

--- a/app/src/app/getting-started/upload-regions/UploadRegionsForm.tsx
+++ b/app/src/app/getting-started/upload-regions/UploadRegionsForm.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import {useFormState} from "react-dom";
+import {Button, buttonVariants} from "@/components/ui/button";
+import {Label} from "@/components/ui/label";
+import {Input} from "@/components/ui/input";
+import Link from "next/link";
+import React from "react";
+import {ErrorBox} from "@/components/ErrorBox";
+import {uploadRegions} from "@/app/getting-started/upload-regions/actions";
+
+const initialState: { error: string | null } = {
+  error: null
+}
+
+export default function UploadRegionsForm() {
+  const [state, formAction] = useFormState(uploadRegions, initialState)
+
+  return (
+    <form action={formAction} className="space-y-6 bg-green-100 p-6">
+      <Label className="block" htmlFor="regions-file">Select regions file:</Label>
+      <Input required id="regions-file" type="file" name="regions"/>
+      {
+        state.error ? (
+          <ErrorBox>
+            <span>{state.error}</span>
+          </ErrorBox>
+        ) : null
+      }
+      <div className="space-x-3">
+        <Button type="submit">Upload</Button>
+        <Link
+          href="/getting-started/upload-custom-activity-standard-codes"
+          className={buttonVariants({variant: 'outline'})}
+        >Skip</Link>
+      </div>
+    </form>
+  )
+}

--- a/app/src/app/getting-started/upload-regions/actions.ts
+++ b/app/src/app/getting-started/upload-regions/actions.ts
@@ -12,7 +12,7 @@ export async function uploadRegions(_prevState: State, formData: FormData): Prom
   try {
     const file = formData.get('regions') as File
     const authFetch = setupAuthorizedFetchFn()
-    const response = await authFetch(`${process.env.SUPABASE_URL}/rest/v1/region_view`, {
+    const response = await authFetch(`${process.env.SUPABASE_URL}/rest/v1/region_upload`, {
       method: 'POST',
       headers: {
         'Content-Type': 'text/csv'

--- a/app/src/app/getting-started/upload-regions/actions.ts
+++ b/app/src/app/getting-started/upload-regions/actions.ts
@@ -27,5 +27,5 @@ export async function uploadRegions(formData: FormData) {
     return {error: 'failed to upload regions'}
   }
 
-  return redirect('/getting-started/upload-legal-units', RedirectType.push)
+  return redirect('/getting-started/upload-custom-activity-standard-codes', RedirectType.push)
 }

--- a/app/src/app/getting-started/upload-regions/actions.ts
+++ b/app/src/app/getting-started/upload-regions/actions.ts
@@ -2,7 +2,7 @@
 import {redirect, RedirectType} from "next/navigation";
 import {setupAuthorizedFetchFn} from "@/lib/supabase/request-helper";
 
-export async function uploadRegions(formData: FormData) {
+export async function uploadRegions(_prevState: { error: string | null }, formData: FormData) {
   "use server";
 
   try {
@@ -20,7 +20,7 @@ export async function uploadRegions(formData: FormData) {
       const data = await response.json()
       console.error(`regions upload failed with status ${response.status} ${response.statusText}`)
       console.error(data)
-      return {error: data.message}
+      return {error: data.message.replace(/,/g, ', ')}
     }
 
   } catch (e) {

--- a/app/src/app/getting-started/upload-regions/actions.ts
+++ b/app/src/app/getting-started/upload-regions/actions.ts
@@ -2,7 +2,11 @@
 import {redirect, RedirectType} from "next/navigation";
 import {setupAuthorizedFetchFn} from "@/lib/supabase/request-helper";
 
-export async function uploadRegions(_prevState: { error: string | null }, formData: FormData) {
+interface State {
+  error: string | null
+}
+
+export async function uploadRegions(_prevState: State, formData: FormData): Promise<State> {
   "use server";
 
   try {

--- a/app/src/app/getting-started/upload-regions/page.tsx
+++ b/app/src/app/getting-started/upload-regions/page.tsx
@@ -1,12 +1,8 @@
 import React from "react";
-import Link from "next/link";
-import {Label} from "@/components/ui/label";
-import {Input} from "@/components/ui/input";
-import {Button, buttonVariants} from "@/components/ui/button";
-import {uploadRegions} from "@/app/getting-started/upload-regions/actions";
 import {Accordion, AccordionContent, AccordionItem, AccordionTrigger} from "@/components/ui/accordion";
 import {InfoBox} from "@/components/InfoBox";
 import {createClient} from "@/lib/supabase/server";
+import UploadRegionsForm from "@/app/getting-started/upload-regions/UploadRegionsForm";
 
 export default async function UploadRegionsPage() {
   const client = createClient()
@@ -26,14 +22,7 @@ export default async function UploadRegionsPage() {
         ) : null
       }
 
-      <form action={uploadRegions} className="space-y-6 bg-green-100 p-6">
-        <Label className="block" htmlFor="regions-file">Select regions file:</Label>
-        <Input required id="regions-file" type="file" name="regions"/>
-        <div className="space-x-3">
-          <Button type="submit">Upload</Button>
-          <Link href="/getting-started/upload-custom-activity-standard-codes" className={buttonVariants({variant: 'outline'})}>Skip</Link>
-        </div>
-      </form>
+      <UploadRegionsForm/>
 
       <Accordion type="single" collapsible>
         <AccordionItem value="Activity Category Standard">

--- a/app/src/app/getting-started/upload-regions/page.tsx
+++ b/app/src/app/getting-started/upload-regions/page.tsx
@@ -20,7 +20,7 @@ export default async function UploadRegionsPage() {
         count && count > 0 ? (
           <InfoBox>
             <p>
-              There are already {count} regions defined. You may skip this step.
+              There are already {count} regions defined.
             </p>
           </InfoBox>
         ) : null
@@ -31,7 +31,7 @@ export default async function UploadRegionsPage() {
         <Input required id="regions-file" type="file" name="regions"/>
         <div className="space-x-3">
           <Button type="submit">Upload</Button>
-          <Link href="/getting-started/upload-legal-units" className={buttonVariants({variant: 'outline'})}>Skip</Link>
+          <Link href="/getting-started/upload-custom-activity-standard-codes" className={buttonVariants({variant: 'outline'})}>Skip</Link>
         </div>
       </form>
 

--- a/app/src/app/search/hooks/useFilter.ts
+++ b/app/src/app/search/hooks/useFilter.ts
@@ -56,7 +56,7 @@ export const useFilter = ({regions = [], activityCategories = [], statisticalVar
     },
     {
       type: "options",
-      name: "region_codes",
+      name: "physical_region_code",
       label: "Region",
       options: regions.map(({code, name}) => (
         {

--- a/app/src/components/CommandPalette.tsx
+++ b/app/src/components/CommandPalette.tsx
@@ -100,6 +100,10 @@ export function CommandPalette() {
             <Upload className="mr-2 h-4 w-4"/>
             <span>Upload Regions</span>
           </CommandItem>
+          <CommandItem onSelect={() => navigate("/getting-started/upload-custom-activity-standard-codes")}>
+            <Upload className="mr-2 h-4 w-4"/>
+            <span>Upload Custom Activity Category Standards</span>
+          </CommandItem>
           <CommandItem onSelect={() => navigate("/getting-started/upload-legal-units")}>
             <Upload className="mr-2 h-4 w-4"/>
             <span>Upload Legal Units</span>

--- a/app/src/components/ErrorBox.tsx
+++ b/app/src/components/ErrorBox.tsx
@@ -1,0 +1,11 @@
+import {AlertCircle} from "lucide-react";
+import React, {ReactNode} from "react";
+
+export const ErrorBox = ({children}: { readonly children: ReactNode }) => (
+  <div className="flex items-center space-x-3 p-6 bg-red-100">
+    <div>
+      <AlertCircle size={32}/>
+    </div>
+    {children}
+  </div>
+)

--- a/app/src/components/InfoBox.tsx
+++ b/app/src/components/InfoBox.tsx
@@ -4,7 +4,7 @@ import {Info} from "lucide-react";
 export const InfoBox = ({children}: { readonly children: ReactNode }) => (
   <div className="flex items-center space-x-3 p-6 bg-amber-100">
     <div>
-      <Info/>
+      <Info size={32}/>
     </div>
     {children}
   </div>

--- a/app/src/lib/database.types.ts
+++ b/app/src/lib/database.types.ts
@@ -1767,13 +1767,6 @@ export interface Database {
             referencedColumns: ["id"]
           },
           {
-            foreignKeyName: "location_region_id_fkey"
-            columns: ["region_id"]
-            isOneToOne: false
-            referencedRelation: "region_view"
-            referencedColumns: ["id"]
-          },
-          {
             foreignKeyName: "location_updated_by_user_id_fkey"
             columns: ["updated_by_user_id"]
             isOneToOne: false
@@ -1955,7 +1948,6 @@ export interface Database {
           name: string
           parent_id: number | null
           path: unknown
-          updated_at: string
         }
         Insert: {
           code?: string | null
@@ -1965,7 +1957,6 @@ export interface Database {
           name: string
           parent_id?: number | null
           path: unknown
-          updated_at?: string
         }
         Update: {
           code?: string | null
@@ -1975,7 +1966,6 @@ export interface Database {
           name?: string
           parent_id?: number | null
           path?: unknown
-          updated_at?: string
         }
         Relationships: [
           {
@@ -1986,24 +1976,10 @@ export interface Database {
             referencedColumns: ["id"]
           },
           {
-            foreignKeyName: "fk_region_region_parent_id"
-            columns: ["parent_id"]
-            isOneToOne: false
-            referencedRelation: "region_view"
-            referencedColumns: ["id"]
-          },
-          {
             foreignKeyName: "region_parent_id_fkey"
             columns: ["parent_id"]
             isOneToOne: false
             referencedRelation: "region"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "region_parent_id_fkey"
-            columns: ["parent_id"]
-            isOneToOne: false
-            referencedRelation: "region_view"
             referencedColumns: ["id"]
           }
         ]
@@ -2030,13 +2006,6 @@ export interface Database {
             columns: ["region_id"]
             isOneToOne: false
             referencedRelation: "region"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "region_role_region_id_fkey"
-            columns: ["region_id"]
-            isOneToOne: false
-            referencedRelation: "region_view"
             referencedColumns: ["id"]
           },
           {
@@ -2510,6 +2479,24 @@ export interface Database {
           parent_code: string | null
           path: unknown | null
           standard_code: string | null
+        }
+        Relationships: []
+      }
+      activity_category_available_custom: {
+        Row: {
+          description: string | null
+          name: string | null
+          path: unknown | null
+        }
+        Insert: {
+          description?: string | null
+          name?: string | null
+          path?: unknown | null
+        }
+        Update: {
+          description?: string | null
+          name?: string | null
+          path?: unknown | null
         }
         Relationships: []
       }
@@ -3322,13 +3309,6 @@ export interface Database {
             referencedColumns: ["id"]
           },
           {
-            foreignKeyName: "location_region_id_fkey"
-            columns: ["region_id"]
-            isOneToOne: false
-            referencedRelation: "region_view"
-            referencedColumns: ["id"]
-          },
-          {
             foreignKeyName: "location_updated_by_user_id_fkey"
             columns: ["updated_by_user_id"]
             isOneToOne: false
@@ -3410,67 +3390,20 @@ export interface Database {
         }
         Relationships: []
       }
-      region_view: {
+      region_upload: {
         Row: {
-          code: string | null
-          id: number | null
-          label: string | null
-          level: number | null
           name: string | null
-          parent_id: number | null
           path: unknown | null
-          updated_at: string | null
         }
         Insert: {
-          code?: string | null
-          id?: number | null
-          label?: string | null
-          level?: number | null
           name?: string | null
-          parent_id?: number | null
           path?: unknown | null
-          updated_at?: string | null
         }
         Update: {
-          code?: string | null
-          id?: number | null
-          label?: string | null
-          level?: number | null
           name?: string | null
-          parent_id?: number | null
           path?: unknown | null
-          updated_at?: string | null
         }
-        Relationships: [
-          {
-            foreignKeyName: "fk_region_region_parent_id"
-            columns: ["parent_id"]
-            isOneToOne: false
-            referencedRelation: "region"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "fk_region_region_parent_id"
-            columns: ["parent_id"]
-            isOneToOne: false
-            referencedRelation: "region_view"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "region_parent_id_fkey"
-            columns: ["parent_id"]
-            isOneToOne: false
-            referencedRelation: "region"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "region_parent_id_fkey"
-            columns: ["parent_id"]
-            isOneToOne: false
-            referencedRelation: "region_view"
-            referencedColumns: ["id"]
-          }
-        ]
+        Relationships: []
       }
       reorg_type_custom: {
         Row: {
@@ -3648,13 +3581,18 @@ export interface Database {
           }
         ]
       }
-      statistical_units: {
+      statistical_unit: {
         Row: {
           enterprise_group_id: number | null
           enterprise_id: number | null
           establishment_id: number | null
           legal_unit_id: number | null
           name: string | null
+          physical_region_id: number | null
+          primary_activity_category_id: number | null
+          secondary_activity_category_id: number | null
+          valid_from: string | null
+          valid_to: string | null
         }
         Relationships: []
       }
@@ -4180,11 +4118,32 @@ export interface Database {
         }
         Returns: string
       }
+      materialised_view_updated_at: {
+        Args: Record<PropertyKey, never>
+        Returns: {
+          materialized_view_name: string
+          updated_at: string
+        }[]
+      }
       nlevel: {
         Args: {
           "": unknown
         }
         Returns: number
+      }
+      refresh_materialized_view: {
+        Args: {
+          materialized_view_name: string
+        }
+        Returns: undefined
+      }
+      refresh_statistical_unit: {
+        Args: Record<PropertyKey, never>
+        Returns: undefined
+      }
+      statistical_unit_updated_at: {
+        Args: Record<PropertyKey, never>
+        Returns: string
       }
       text2ltree: {
         Args: {


### PR DESCRIPTION
Some countries might have their own category standard codes in addition, or instead of the **NACE / ISIC** standard codes. This PR adds a new upload page where the user can upload custom category standard codes.

This PR also adds error feedback whenever file uploads fail so that the user will know what has gone wrong.

**Example:**
Uploading a legal units file in regions upload form results in this error:

![Screenshot 2024-01-26 at 17 34 39](https://github.com/statisticsnorway/statbus/assets/937001/a6f62e80-50ad-4a1a-b043-501242e9c239)
