### PR TITLE
[ui] Add tax_reg_id in search result and improve filter UX

### DIFF
--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -5,7 +5,7 @@ export default async function Home() {
   const client = createClient();
   const {data: statisticalUnits, count, error: legalUnitsError} = await client
     .from('statistical_unit')
-    .select('name, primary_activity_category_path, legal_unit_id, physical_region_path', {count: 'exact'})
+    .select('name, tax_reg_ident, primary_activity_category_path, legal_unit_id, physical_region_path', {count: 'exact'})
     .order('enterprise_id', {ascending: false})
     .limit(10);
 

--- a/app/src/app/search/api/route.ts
+++ b/app/src/app/search/api/route.ts
@@ -13,7 +13,7 @@ export async function GET(request: Request) {
     }
 
     if (!searchParams.has('select')) {
-        searchParams.set('select', 'name, primary_activity_category_path, legal_unit_id, physical_region_path')
+        searchParams.set('select', 'name, tax_reg_ident, primary_activity_category_path, legal_unit_id, physical_region_path')
     }
 
     const authFetch = setupAuthorizedFetchFn()

--- a/app/src/app/search/components/search-result-table.tsx
+++ b/app/src/app/search/components/search-result-table.tsx
@@ -23,16 +23,17 @@ export default function SearchResultTable({searchResult: {statisticalUnits}, reg
       </TableHeader>
       <TableBody>
         {
-          statisticalUnits?.map(({legal_unit_id, name, physical_region_path, primary_activity_category_path}) => (
-            <TableRow key={legal_unit_id}>
-              <TableCell className="p-3">
-                <Link href={`/legal-units/${legal_unit_id}`} className="font-medium">
-                  {name}
-                </Link>
-              </TableCell>
-              <TableCell className="p-3 text-right">{getRegionByPath(physical_region_path)?.name}</TableCell>
-              <TableCell className="text-right p-3 px-4">{primary_activity_category_path as string}</TableCell>
-            </TableRow>
+          statisticalUnits?.map(({legal_unit_id, tax_reg_ident, name, physical_region_path, primary_activity_category_path}) => (
+              <TableRow key={legal_unit_id}>
+                  <TableCell className="p-2 flex flex-col space-y-1.5">
+                      <Link href={`/legal-units/${legal_unit_id}`} className="font-medium leading-none">
+                          {name}
+                      </Link>
+                      <small className="text-gray-700 leading-none">{tax_reg_ident}</small>
+                  </TableCell>
+                  <TableCell className="p-2 text-right">{getRegionByPath(physical_region_path)?.name}</TableCell>
+                  <TableCell className="text-right p-2 px-4">{primary_activity_category_path as string}</TableCell>
+              </TableRow>
           ))
         }
       </TableBody>

--- a/app/src/app/search/hooks/use-filter.ts
+++ b/app/src/app/search/hooks/use-filter.ts
@@ -67,7 +67,7 @@ export const useFilter = ({regions = [], activityCategories = [], statisticalVar
         {
           label: `${code} ${name}`,
           value: path as string,
-          humanReadableValue: name
+          humanReadableValue: `${code} ${name}`
         }
       )),
       selected: [],
@@ -81,7 +81,7 @@ export const useFilter = ({regions = [], activityCategories = [], statisticalVar
         {
           label: `${code} ${name}`,
           value: path as string,
-          humanReadableValue: name?.toString()
+          humanReadableValue: `${code} ${name}`
         }
       )),
       selected: [],


### PR DESCRIPTION
Display statistical unit tax_reg_id next to name. Also include region code next to region name and activity category code next to name in filter value view.