### PR TITLE
[ui] Display custom category count on getting-started summary page

### DIFF
--- a/app/src/app/getting-started/summary/page.tsx
+++ b/app/src/app/getting-started/summary/page.tsx
@@ -4,92 +4,92 @@ import {AlertCircle, Check} from "lucide-react";
 import {createClient} from "@/lib/supabase/server";
 
 export default async function OnboardingCompletedPage() {
-  const client = createClient()
-  const {data: settings} = await client.from('settings').select('id, activity_category_standard(id,name)')
-  const {data: regions} = await client.from('region').select('id, name')
-  const {data: legalUnits} = await client.from('legal_unit').select('id, name')
+    const client = createClient()
+    const {data: settings, count: numberOfSettings} = await client.from('settings').select('id, activity_category_standard(id,name)', {count: 'exact'}).limit(1)
+    const {count: numberOfRegions} = await client.from('region').select('id', {count: 'exact'}).limit(1)
+    const {count: numberOfLegalUnits} = await client.from('legal_unit').select('id', {count: 'exact'}).limit(1)
 
-  return (
-    <div className="space-y-8">
-      <h1 className="font-medium text-lg text-center">Summary</h1>
+    return (
+        <div className="space-y-8">
+            <h1 className="font-medium text-lg text-center">Summary</h1>
 
 
-      <div className="flex items-center space-x-3">
-        <div>
-          {
-            settings?.length ? <Check/> : <AlertCircle/>
-          }
+            <div className="flex items-center space-x-3">
+                <div>
+                    {
+                        numberOfSettings ? <Check/> : <AlertCircle/>
+                    }
+                </div>
+                <p>
+                    {
+                        numberOfSettings ? (
+                            <>
+                                You have configured StatBus to use
+                                the <strong>{settings?.[0]?.activity_category_standard?.name}</strong> activity category
+                                standard.
+                            </>
+                        ) : (
+                            <>
+                                You have not configured StatBus to use an activity category standard. You can configure
+                                activity category standards&nbsp;
+                                <Link className="underline" href={"/getting-started/activity-standard"}>here</Link>
+                            </>
+                        )
+                    }
+                </p>
+            </div>
+
+            <div className="flex items-center space-x-3">
+                <div>
+                    {
+                        numberOfRegions ? <Check/> : <AlertCircle/>
+                    }
+                </div>
+                <p>
+                    {
+                        numberOfRegions ? (
+                            <>
+                                You have uploaded <strong>{numberOfRegions}</strong> regions.
+                            </>
+                        ) : (
+                            <>
+                                You have not uploaded any regions. You can upload regions&nbsp;
+                                <Link className="underline" href={"/getting-started/upload-regions"}> here</Link>
+                            </>
+                        )
+                    }
+                </p>
+            </div>
+
+            <div className="flex items-center space-x-3">
+                <div>
+                    {
+                        numberOfLegalUnits ? <Check/> : <AlertCircle/>
+                    }
+                </div>
+                <p>
+                    {
+                        numberOfLegalUnits ? (
+                            <>
+                                You have uploaded <strong>{numberOfLegalUnits}</strong> legal units.
+                            </>
+                        ) : (
+                            <>
+                                You have not uploaded any legal units. You can do so&nbsp;
+                                <Link className="underline" href={"/getting-started/upload-legal-units"}>here</Link>
+                            </>
+                        )
+                    }
+                </p>
+            </div>
+
+            {
+                numberOfSettings && numberOfRegions && numberOfLegalUnits ? (
+                    <div className="text-center">
+                        <Link className="underline" href="/">Start using StatBus</Link>
+                    </div>
+                ) : null
+            }
         </div>
-        <p>
-          {
-            settings?.length ? (
-              <>
-                You have configured StatBus to use
-                the <strong>{settings?.[0]?.activity_category_standard?.name}</strong> activity category
-                standard.
-              </>
-            ) : (
-              <>
-                You have not configured StatBus to use an activity category standard. You can configure
-                activity category standards&nbsp;
-                <Link className="underline" href={"/getting-started/activity-standard"}>here</Link>
-              </>
-            )
-          }
-        </p>
-      </div>
-
-      <div className="flex items-center space-x-3">
-        <div>
-          {
-            regions?.length ? <Check/> : <AlertCircle/>
-          }
-        </div>
-        <p>
-          {
-            regions?.length ? (
-              <>
-                You have uploaded <strong>{regions.length}</strong> regions.
-              </>
-            ) : (
-              <>
-                You have not uploaded any regions. You can upload regions&nbsp;
-                <Link className="underline" href={"/getting-started/upload-regions"}>   here</Link>
-              </>
-            )
-          }
-        </p>
-      </div>
-
-      <div className="flex items-center space-x-3">
-        <div>
-          {
-            legalUnits?.length ? <Check/> : <AlertCircle/>
-          }
-        </div>
-        <p>
-          {
-            legalUnits?.length ? (
-              <>
-                You have uploaded <strong>{legalUnits.length}</strong> legal units.
-              </>
-            ) : (
-              <>
-                You have not uploaded any legal units. You can do so&nbsp;
-                <Link className="underline" href={"/getting-started/upload-legal-units"}>here</Link>
-              </>
-            )
-          }
-        </p>
-      </div>
-
-      {
-        settings?.length && regions?.length && legalUnits?.length ? (
-          <div className="text-center">
-            <Link className="underline" href="/">Start using StatBus</Link>
-          </div>
-        ) : null
-      }
-    </div>
-  )
+    )
 }

--- a/app/src/app/getting-started/summary/page.tsx
+++ b/app/src/app/getting-started/summary/page.tsx
@@ -11,104 +11,38 @@ export default async function OnboardingCompletedPage() {
     const {count: numberOfCustomActivityCategoryCodes} = await client.from('activity_category_available_custom').select('path', {count: 'exact'}).limit(1)
 
     return (
-        <div className="space-y-8">
+        <div className="space-y-12">
             <h1 className="font-medium text-lg text-center">Summary</h1>
 
+            <div className="space-y-6">
 
-            <div className="flex items-center space-x-3">
-                <div>
-                    {
-                        numberOfSettings ? <Check/> : <X/>
-                    }
-                </div>
-                <p>
-                    {
-                        numberOfSettings ? (
-                            <>
-                                You have configured StatBus to use
-                                the <strong>{settings?.[0]?.activity_category_standard?.name}</strong> activity category
-                                standard.
-                            </>
-                        ) : (
-                            <>
-                                You have not configured StatBus to use an activity category standard. You can configure
-                                activity category standards&nbsp;
-                                <Link className="underline" href={"/getting-started/activity-standard"}>here</Link>
-                            </>
-                        )
-                    }
-                </p>
-            </div>
+                <SummaryBlock
+                    success={!!numberOfSettings}
+                    successText={`You have configured StatBus to use the activity category standard ${settings?.[0]?.activity_category_standard?.name}.`}
+                    failureText={"You have not configured StatBus to use an activity category standard."}
+                    failureLink={"/getting-started/activity-standard"}
+                />
 
-            <div className="flex items-center space-x-3">
-                <div>
-                    {
-                        numberOfCustomActivityCategoryCodes ? <Check/> : <X/>
-                    }
-                </div>
-                <p>
-                    {
-                        numberOfCustomActivityCategoryCodes ? (
-                            <>
-                                You have configured StatBus to use
-                                the <strong>{numberOfCustomActivityCategoryCodes}</strong> custom activity category
-                                codes.
-                            </>
-                        ) : (
-                            <>
-                                You have not configured StatBus to use any custom activity category codes. You can
-                                configure
-                                custom activity category standards&nbsp;
-                                <Link className="underline"
-                                      href={"/getting-started/upload-custom-activity-standard-codes"}>here</Link>
-                            </>
-                        )
-                    }
-                </p>
-            </div>
+                <SummaryBlock
+                    success={!!numberOfCustomActivityCategoryCodes}
+                    successText={`You have configured StatBus to use ${numberOfCustomActivityCategoryCodes} custom activity category codes.`}
+                    failureText="You have not configured StatBus to use any custom activity category codes."
+                    failureLink={"/getting-started/upload-custom-activity-standard-codes"}
+                />
 
-            <div className="flex items-center space-x-3">
-                <div>
-                    {
-                        numberOfRegions ? <Check/> : <X/>
-                    }
-                </div>
-                <p>
-                    {
-                        numberOfRegions ? (
-                            <>
-                                You have uploaded <strong>{numberOfRegions}</strong> regions.
-                            </>
-                        ) : (
-                            <>
-                                You have not uploaded any regions. You can upload regions&nbsp;
-                                <Link className="underline" href={"/getting-started/upload-regions"}> here</Link>
-                            </>
-                        )
-                    }
-                </p>
-            </div>
+                <SummaryBlock
+                    success={!!numberOfRegions}
+                    successText={`You have uploaded ${numberOfRegions} regions.`}
+                    failureText="You have not uploaded any regions."
+                    failureLink={"/getting-started/upload-regions"}
+                />
 
-            <div className="flex items-center space-x-3">
-                <div>
-                    {
-                        numberOfLegalUnits ? <Check/> : <X/>
-                    }
-                </div>
-                <p>
-                    {
-                        numberOfLegalUnits ? (
-                            <>
-                                You have uploaded <strong>{numberOfLegalUnits}</strong> legal units.
-                            </>
-                        ) : (
-                            <>
-                                You have not uploaded any legal units. You can do so&nbsp;
-                                <Link className="underline" href={"/getting-started/upload-legal-units"}>here</Link>
-                            </>
-                        )
-                    }
-                </p>
+                <SummaryBlock
+                    success={!!numberOfLegalUnits}
+                    successText={`You have uploaded ${numberOfLegalUnits} legal units.`}
+                    failureText="You have not uploaded any legal units."
+                    failureLink={"/getting-started/upload-legal-units"}
+                />
             </div>
 
             {
@@ -118,6 +52,23 @@ export default async function OnboardingCompletedPage() {
                     </div>
                 ) : null
             }
+        </div>
+    )
+}
+
+const SummaryBlock = ({success, successText, failureText, failureLink}: { success: boolean, successText: string, failureText: string, failureLink: string }) => {
+    return (
+        <div className="flex items-center space-x-6">
+            <div>
+                {
+                    success ? <Check/> : <X/>
+                }
+            </div>
+            <p>
+                {
+                    success ? successText : <Link className="underline" href={failureLink}>{failureText}</Link>
+                }
+            </p>
         </div>
     )
 }

--- a/app/src/app/getting-started/summary/page.tsx
+++ b/app/src/app/getting-started/summary/page.tsx
@@ -1,13 +1,14 @@
 import React from "react";
 import Link from "next/link";
-import {AlertCircle, Check} from "lucide-react";
+import {Check, X} from "lucide-react";
 import {createClient} from "@/lib/supabase/server";
 
 export default async function OnboardingCompletedPage() {
     const client = createClient()
-    const {data: settings, count: numberOfSettings} = await client.from('settings').select('id, activity_category_standard(id,name)', {count: 'exact'}).limit(1)
+    const {data: settings, count: numberOfSettings} = await client.from('settings').select('activity_category_standard(id,name)', {count: 'exact'}).limit(1)
     const {count: numberOfRegions} = await client.from('region').select('id', {count: 'exact'}).limit(1)
     const {count: numberOfLegalUnits} = await client.from('legal_unit').select('id', {count: 'exact'}).limit(1)
+    const {count: numberOfCustomActivityCategoryCodes} = await client.from('activity_category_available_custom').select('path', {count: 'exact'}).limit(1)
 
     return (
         <div className="space-y-8">
@@ -17,7 +18,7 @@ export default async function OnboardingCompletedPage() {
             <div className="flex items-center space-x-3">
                 <div>
                     {
-                        numberOfSettings ? <Check/> : <AlertCircle/>
+                        numberOfSettings ? <Check/> : <X/>
                     }
                 </div>
                 <p>
@@ -42,7 +43,34 @@ export default async function OnboardingCompletedPage() {
             <div className="flex items-center space-x-3">
                 <div>
                     {
-                        numberOfRegions ? <Check/> : <AlertCircle/>
+                        numberOfCustomActivityCategoryCodes ? <Check/> : <X/>
+                    }
+                </div>
+                <p>
+                    {
+                        numberOfCustomActivityCategoryCodes ? (
+                            <>
+                                You have configured StatBus to use
+                                the <strong>{numberOfCustomActivityCategoryCodes}</strong> custom activity category
+                                codes.
+                            </>
+                        ) : (
+                            <>
+                                You have not configured StatBus to use any custom activity category codes. You can
+                                configure
+                                custom activity category standards&nbsp;
+                                <Link className="underline"
+                                      href={"/getting-started/upload-custom-activity-standard-codes"}>here</Link>
+                            </>
+                        )
+                    }
+                </p>
+            </div>
+
+            <div className="flex items-center space-x-3">
+                <div>
+                    {
+                        numberOfRegions ? <Check/> : <X/>
                     }
                 </div>
                 <p>
@@ -64,7 +92,7 @@ export default async function OnboardingCompletedPage() {
             <div className="flex items-center space-x-3">
                 <div>
                     {
-                        numberOfLegalUnits ? <Check/> : <AlertCircle/>
+                        numberOfLegalUnits ? <Check/> : <X/>
                     }
                 </div>
                 <p>


### PR DESCRIPTION
**Work:**
- Display number of custom categories configured
- Refactor summary page to reuse common _SummaryBlock_ component for reduced code duplication