### PR TITLE
[ui] Add command palette action for refreshing materialized search view

### DIFF
--- a/app/src/components/command-palette/command-palette-actions.ts
+++ b/app/src/components/command-palette/command-palette-actions.ts
@@ -7,11 +7,13 @@ export async function refreshStatisticalUnits() {
   const client = createClient()
 
   try {
-    const {status, statusText} = await client.rpc('statistical_unit_refresh_now')
+    const {status, statusText, data} = await client.rpc('statistical_unit_refresh_now')
 
     if (status >= 400) {
       return {error: statusText}
     }
+
+    return {error: null, data}
 
   } catch (error) {
     return {error: "Error refreshing statistical units"}

--- a/app/src/components/command-palette/command-palette-actions.ts
+++ b/app/src/components/command-palette/command-palette-actions.ts
@@ -2,60 +2,76 @@
 
 import {createClient} from "@/lib/supabase/server";
 
-export async function resetLegalUnits() {
-    "use server";
-    const client = createClient()
+export async function refreshStatisticalUnits() {
+  "use server";
+  const client = createClient()
 
-    try {
-        const response = await client
-            .from('legal_unit')
-            .delete()
-            .gt('id', 0)
+  try {
+    const {status, statusText} = await client.rpc('statistical_unit_refresh_now')
 
-        if (response.status >= 400) {
-            console.error('failed to reset legal units', response.error)
-            return {error: response.statusText}
-        }
-
-    } catch (error) {
-        return {error: "Error resetting legal units"}
+    if (status >= 400) {
+      return {error: statusText}
     }
+
+  } catch (error) {
+    return {error: "Error refreshing statistical units"}
+  }
+}
+
+export async function resetLegalUnits() {
+  "use server";
+  const client = createClient()
+
+  try {
+    const response = await client
+      .from('legal_unit')
+      .delete()
+      .gt('id', 0)
+
+    if (response.status >= 400) {
+      console.error('failed to reset legal units', response.error)
+      return {error: response.statusText}
+    }
+
+  } catch (error) {
+    return {error: "Error resetting legal units"}
+  }
 }
 
 export async function resetRegions() {
-    "use server";
-    const client = createClient()
+  "use server";
+  const client = createClient()
 
-    try {
-        const response = await client
-            .from('region')
-            .delete()
-            .gt('id', 0)
+  try {
+    const response = await client
+      .from('region')
+      .delete()
+      .gt('id', 0)
 
-        if (response.status >= 400) {
-            return {error: response.statusText}
-        }
-
-    } catch (error) {
-        return {error: "Error resetting regions"}
+    if (response.status >= 400) {
+      return {error: response.statusText}
     }
+
+  } catch (error) {
+    return {error: "Error resetting regions"}
+  }
 }
 
 export async function resetSettings() {
-    "use server";
-    const client = createClient()
+  "use server";
+  const client = createClient()
 
-    try {
-        const response = await client
-            .from('settings')
-            .delete()
-            .eq('only_one_setting', true)
+  try {
+    const response = await client
+      .from('settings')
+      .delete()
+      .eq('only_one_setting', true)
 
-        if (response.status >= 400) {
-            return {error: response.statusText}
-        }
-
-    } catch (error) {
-        return {error: "Error resetting settings"}
+    if (response.status >= 400) {
+      return {error: response.statusText}
     }
+
+  } catch (error) {
+    return {error: "Error resetting settings"}
+  }
 }

--- a/app/src/components/command-palette/command-palette.tsx
+++ b/app/src/components/command-palette/command-palette.tsx
@@ -3,8 +3,13 @@
 import * as React from "react"
 import {useToast} from "@/components/ui/use-toast";
 import {useRouter} from "next/navigation";
-import {Footprints, Home, Pilcrow, Trash, Upload, User} from "lucide-react"
-import {resetLegalUnits, resetRegions, resetSettings} from "@/components/command-palette/command-palette-actions";
+import {Footprints, Home, ListRestart, Pilcrow, Trash, Upload, User} from "lucide-react"
+import {
+  refreshStatisticalUnits,
+  resetLegalUnits,
+  resetRegions,
+  resetSettings
+} from "@/components/command-palette/command-palette-actions";
 
 import {
   CommandDialog,
@@ -60,6 +65,15 @@ export function CommandPalette() {
     })
   }
 
+  const handleStatisticalUnitsRefresh = async () => {
+    setOpen(false)
+    const response = await refreshStatisticalUnits()
+    toast({
+      title: response?.error ? "Statistical Units Refresh Failed" : "Statistical Units Refresh OK",
+      description: response?.error ?? "All Statistical Units have been refreshed.",
+    })
+  }
+
   const navigate = (path: string) => {
     setOpen(false)
     router.push(path)
@@ -82,6 +96,10 @@ export function CommandPalette() {
           <CommandItem onSelect={handleLegalUnitsReset}>
             <Trash className="mr-2 h-4 w-4"/>
             <span>Reset Legal Units</span>
+          </CommandItem>
+          <CommandItem onSelect={handleStatisticalUnitsRefresh}>
+            <ListRestart className="mr-2 h-4 w-4"/>
+            <span>Refresh Statistical Units</span>
           </CommandItem>
         </CommandGroup>
         <CommandSeparator/>

--- a/app/src/components/command-palette/command-palette.tsx
+++ b/app/src/components/command-palette/command-palette.tsx
@@ -70,7 +70,7 @@ export function CommandPalette() {
     const response = await refreshStatisticalUnits()
     toast({
       title: response?.error ? "Statistical Units Refresh Failed" : "Statistical Units Refresh OK",
-      description: response?.error ?? "All Statistical Units have been refreshed.",
+      description: response?.error ?? response?.data ?? "Statistical Units have been refreshed.",
     })
   }
 


### PR DESCRIPTION
The command palette action will invoke rpc statistical_unit_refresh_now that in turn will refresh the view statistical_unit used by StatBus search