### PR TITLE
[ui] Implement materialized views for region and category search filters

### DIFF
--- a/app/src/app/search/page.tsx
+++ b/app/src/app/search/page.tsx
@@ -15,11 +15,11 @@ export default async function SearchPage() {
         .limit(10);
 
     const regionPromise = client
-        .from('region')
+        .from('region_used')
         .select()
 
     const activityCategoryPromise = client
-        .from('activity_category_available')
+        .from('activity_category_used')
         .select();
 
     const statDefinitionPromise = client

--- a/app/src/components/command-palette/command-palette.tsx
+++ b/app/src/components/command-palette/command-palette.tsx
@@ -78,8 +78,12 @@ export function CommandPalette() {
         setOpen(false)
         const response = await refreshStatisticalUnits()
         toast({
-            title: response?.error ? "Statistical Units Refresh Failed" : "Statistical Units Refresh OK",
-            description: response?.error ?? response?.data ?? "Statistical Units have been refreshed.",
+          title: response?.error ? "Statistical Units Refresh Failed" : "Statistical Units successfully refreshed.",
+          description: response?.error ?? (
+            <pre className="mt-2 rounded-md bg-slate-950 p-4">
+              <code className="text-white text-xs">{JSON.stringify(response.data, null, 2)}</code>
+            </pre>
+          ) ?? "Statistical Units have been refreshed.",
         })
     }
 


### PR DESCRIPTION
New views _region_used_ and _activity_category_used_ return only regions and categories that are in use by our statistical units. This improves the UX when filtering search results because the user is not given a bunch of alternatives that yield no data.