### PR TITLE
[ui] Add unit type filter to stat unit search

### DIFF
--- a/app/src/app/search/hooks/use-filter.ts
+++ b/app/src/app/search/hooks/use-filter.ts
@@ -60,6 +60,18 @@ export const useFilter = ({regions = [], activityCategories = [], statisticalVar
       postgrestQuery: ({selected}) => selected.length ? `eq.${selected[0]}` : null
     },
     {
+      type: "options",
+      label: "Type",
+      name: "unit_type",
+      options: [
+          {label: "Legal Unit", value: "legal_unit"},
+          {label: "Establishment", value: "establishment"},
+          {label: "Enterprise", value: "enterprise"},
+      ],
+      selected: ["enterprise"],
+      postgrestQuery: ({selected}) => selected.length ? `in.(${selected.join(',')})` : null
+    },
+    {
       type: "radio",
       name: "physical_region_path",
       label: "Region",

--- a/app/src/app/search/page.tsx
+++ b/app/src/app/search/page.tsx
@@ -11,6 +11,7 @@ export default async function SearchPage() {
     const statisticalUnitPromise = client
         .from('statistical_unit')
         .select('name, tax_reg_ident, primary_activity_category_path, unit_id, unit_type, physical_region_path', {count: 'exact'})
+        .in('unit_type', ['enterprise'])
         .order('tax_reg_ident', {ascending: false})
         .limit(10);
 


### PR DESCRIPTION
This PR adds a new search filter for `unit_type`. This let's the user filter search results by _enterprises_, _legal_units_ and _establishments_