### PR TITLE
[ui] Display and export report / graph data

### DIFF
--- a/app/src/app/reports/drill-down-chart.tsx
+++ b/app/src/app/reports/drill-down-chart.tsx
@@ -13,9 +13,8 @@ export const DrillDownChart = ({points, onSelect}: DrillDownChartProps) => {
     const _chart = useRef<Chart | null>(null)
 
     useEffect(() => {
-        _chart.current?.destroy();
-
         if (_ref.current) {
+            _chart.current?.destroy();
             _chart.current = chart({
                 chart: {
                     renderTo: _ref.current,

--- a/app/src/app/reports/search-link.tsx
+++ b/app/src/app/reports/search-link.tsx
@@ -1,0 +1,29 @@
+import {DrillDownPoint} from "@/app/reports/types/drill-down";
+import {Button} from "@/components/ui/button";
+import Link from "next/link";
+import {PHYSICAL_REGION_PATH, PRIMARY_ACTIVITY_CATEGORY_PATH} from "@/app/search/constants";
+
+export const SearchLink = ({region, activityCategory}: {
+  readonly region: DrillDownPoint | null,
+  readonly activityCategory: DrillDownPoint | null
+}) => {
+
+  const searchParams = new URLSearchParams();
+
+  if (region) {
+    searchParams.set(PHYSICAL_REGION_PATH, region.path);
+  }
+
+  if (activityCategory) {
+    searchParams.set(PRIMARY_ACTIVITY_CATEGORY_PATH, activityCategory.path);
+  }
+
+  return (
+    <Button asChild>
+      <Link
+        href={searchParams.size ? `/search?${searchParams}` : '/search'}>
+        View and export statistical units
+      </Link>
+    </Button>
+  )
+}

--- a/app/src/app/reports/statbus-chart.tsx
+++ b/app/src/app/reports/statbus-chart.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import {useCallback, useEffect} from "react";
-import {DrillDown, DrillDownPoint} from "@/app/reports/types/drill-down";
+import {useEffect} from "react";
+import {DrillDown} from "@/app/reports/types/drill-down";
 import * as highcharts from "highcharts";
 import HC_drilldown from "highcharts/modules/drilldown";
 import HC_a11y from "highcharts/modules/accessibility";
@@ -10,7 +10,6 @@ import {DrillDownChart} from "@/app/reports/drill-down-chart";
 import {useDrillDownData} from "@/app/reports/use-drill-down-data";
 import {InfoBox} from "@/components/info-box";
 
-
 export default function StatBusChart(props: { readonly drillDown: DrillDown }) {
     const {drillDown, region, setRegion, activityCategory, setActivityCategory} = useDrillDownData(props.drillDown);
 
@@ -18,14 +17,6 @@ export default function StatBusChart(props: { readonly drillDown: DrillDown }) {
         HC_a11y(highcharts);
         HC_drilldown(highcharts);
     }, []);
-
-    const selectRegion = useCallback((point: DrillDownPoint) => {
-        setRegion(point);
-    }, [setRegion]);
-
-    const selectActivityCategory = useCallback((point: DrillDownPoint) => {
-        setActivityCategory(point);
-    }, [setActivityCategory]);
 
     return (
         <div className="w-full space-y-12 p-6">
@@ -45,7 +36,7 @@ export default function StatBusChart(props: { readonly drillDown: DrillDown }) {
                 />
                 <DrillDownChart
                     points={drillDown.available.region}
-                    onSelect={selectRegion}
+                    onSelect={setRegion}
                 />
             </div>
             <div className="p-6 space-y-6 border-l-4 border-gray-200 bg-gray-50">
@@ -57,7 +48,7 @@ export default function StatBusChart(props: { readonly drillDown: DrillDown }) {
                 />
                 <DrillDownChart
                     points={drillDown.available.activity_category}
-                    onSelect={selectActivityCategory}
+                    onSelect={setActivityCategory}
                 />
             </div>
         </div>

--- a/app/src/app/reports/statbus-chart.tsx
+++ b/app/src/app/reports/statbus-chart.tsx
@@ -9,6 +9,7 @@ import {BreadCrumb} from "@/app/reports/bread-crumb";
 import {DrillDownChart} from "@/app/reports/drill-down-chart";
 import {useDrillDownData} from "@/app/reports/use-drill-down-data";
 import {InfoBox} from "@/components/info-box";
+import {SearchLink} from "@/app/reports/search-link";
 
 export default function StatBusChart(props: { readonly drillDown: DrillDown }) {
     const {drillDown, region, setRegion, activityCategory, setActivityCategory} = useDrillDownData(props.drillDown);
@@ -51,6 +52,10 @@ export default function StatBusChart(props: { readonly drillDown: DrillDown }) {
                     onSelect={setActivityCategory}
                 />
             </div>
+
+          <div className="flex justify-end p-6 space-y-6 bg-gray-100">
+            <SearchLink region={region} activityCategory={activityCategory}/>
+          </div>
         </div>
     )
 }

--- a/app/src/app/search/constants.ts
+++ b/app/src/app/search/constants.ts
@@ -1,0 +1,2 @@
+export const PHYSICAL_REGION_PATH = 'physical_region_path';
+export const PRIMARY_ACTIVITY_CATEGORY_PATH = 'primary_activity_category_path';

--- a/app/src/app/search/hooks/use-filter.ts
+++ b/app/src/app/search/hooks/use-filter.ts
@@ -1,6 +1,7 @@
 import {Tables} from "@/lib/database.types";
 import {useReducer} from "react";
 import type {SearchFilter, SearchFilterActions} from "@/app/search/search.types";
+import {useSearchParams} from "next/navigation";
 
 function searchFilterReducer(state: SearchFilter[], action: SearchFilterActions): SearchFilter[] {
   switch (action.type) {
@@ -42,7 +43,11 @@ interface FilterOptions {
   statisticalVariables: Tables<"stat_definition">[]
 }
 
+const PHYSICAL_REGION_PATH = 'physical_region_path';
+const PRIMARY_ACTIVITY_CATEGORY_PATH = 'primary_activity_category_path';
+
 export const useFilter = ({regions = [], activityCategories = [], statisticalVariables = []}: FilterOptions) => {
+  const urlSearchParams = useSearchParams()
   const standardFilters: SearchFilter[] = [
     {
       type: "search",
@@ -82,7 +87,7 @@ export const useFilter = ({regions = [], activityCategories = [], statisticalVar
           humanReadableValue: `${code} ${name}`
         }
       )),
-      selected: [],
+      selected: urlSearchParams?.has(PHYSICAL_REGION_PATH) ? [urlSearchParams?.get(PHYSICAL_REGION_PATH) as string] : [],
       postgrestQuery: ({selected}) => selected.length ? `cd.${selected.join()}` : null
     },
     {
@@ -96,7 +101,7 @@ export const useFilter = ({regions = [], activityCategories = [], statisticalVar
           humanReadableValue: `${code} ${name}`
         }
       )),
-      selected: [],
+      selected: urlSearchParams?.has(PRIMARY_ACTIVITY_CATEGORY_PATH) ? [urlSearchParams?.get(PRIMARY_ACTIVITY_CATEGORY_PATH) as string] : [],
       postgrestQuery: ({selected}) => selected.length ? `cd.${selected.join()}` : null
     }
   ];

--- a/app/src/app/search/hooks/use-filter.ts
+++ b/app/src/app/search/hooks/use-filter.ts
@@ -2,6 +2,7 @@ import {Tables} from "@/lib/database.types";
 import {useReducer} from "react";
 import type {SearchFilter, SearchFilterActions} from "@/app/search/search.types";
 import {useSearchParams} from "next/navigation";
+import {PHYSICAL_REGION_PATH, PRIMARY_ACTIVITY_CATEGORY_PATH} from "@/app/search/constants";
 
 function searchFilterReducer(state: SearchFilter[], action: SearchFilterActions): SearchFilter[] {
   switch (action.type) {
@@ -42,9 +43,6 @@ interface FilterOptions {
   regions: Tables<"region_used">[]
   statisticalVariables: Tables<"stat_definition">[]
 }
-
-const PHYSICAL_REGION_PATH = 'physical_region_path';
-const PRIMARY_ACTIVITY_CATEGORY_PATH = 'primary_activity_category_path';
 
 export const useFilter = ({regions = [], activityCategories = [], statisticalVariables = []}: FilterOptions) => {
   const urlSearchParams = useSearchParams()


### PR DESCRIPTION
**The problem:**
The _/reports_ page gives the user a way to drill down in regions and categories, but there is no way to see the actual data that the graphs are based on. This is due to the fact that the reports are based on an aggregated, materialized view optimized for graphing purposes.

**Proposed solution:**
One way to let the user export the data from the reports page is to combine the _reports_ and _search_ page. When the user drill down on `regions` and `categories` we can compose a `{region, activity_category}` search filter and pass this filter to the _search_ page to get the statistical data from on the search page.