### PR TITLE
[ui] Keep sub path when navigating between units in hierarchy

### DIFF
--- a/app/src/app/establishments/[id]/[...slug]/page.tsx
+++ b/app/src/app/establishments/[id]/[...slug]/page.tsx
@@ -1,0 +1,5 @@
+import {redirect, RedirectType} from "next/navigation";
+
+export default function Fallback({params: {id}}: { readonly params: { id: string } }) {
+    redirect(`/establishments/${id}`, RedirectType.replace)
+}

--- a/app/src/app/establishments/[id]/inspect/page.tsx
+++ b/app/src/app/establishments/[id]/inspect/page.tsx
@@ -11,7 +11,7 @@ export default async function EstablishmentInspectionPage({params: {id}}: { read
   }
 
   return (
-    <DetailsPage title="Data dump" subtitle={`This section shows the raw data we have on ${unit?.name}`}>
+    <DetailsPage title="Data Dump" subtitle={`This section shows the raw data we have on ${unit?.name}`}>
       <DataDump data={unit}/>
     </DetailsPage>
   )

--- a/app/src/app/legal-units/[id]/[...slug]/page.tsx
+++ b/app/src/app/legal-units/[id]/[...slug]/page.tsx
@@ -1,0 +1,5 @@
+import {redirect, RedirectType} from "next/navigation";
+
+export default function Fallback({params: {id}}: { readonly params: { id: string } }) {
+    redirect(`/legal-units/${id}`, RedirectType.replace)
+}

--- a/app/src/app/legal-units/components/submission-feedback-debug-info.tsx
+++ b/app/src/app/legal-units/components/submission-feedback-debug-info.tsx
@@ -8,7 +8,7 @@ export function SubmissionFeedbackDebugInfo({state}: {
 }) {
   return state?.status ? (
     <DataDump
-      className={cn('block text-xs', state.status === "success" ? "bg-green-100" : "bg-red-100")}
+      className={cn('block text-xs text-black', state.status === "success" ? "bg-green-100" : "bg-red-100")}
       data={state}
     />
   ) : null

--- a/app/src/components/data-dump.tsx
+++ b/app/src/components/data-dump.tsx
@@ -2,8 +2,8 @@ import {cn} from "@/lib/utils";
 
 export default function DataDump({data, className}: { readonly data: Object, readonly className?: string }) {
   return (
-    <pre className={cn("mt-2 rounded-md bg-slate-950 p-4", className)}>
-      <code className="text-white text-xs">
+    <pre className={cn("mt-2 text-white text-xs rounded-md bg-slate-950 p-4", className)}>
+      <code>
         {
           JSON.stringify(data, null, 2)
         }

--- a/app/src/components/statistical-unit-details-link-with-sub-path.tsx
+++ b/app/src/components/statistical-unit-details-link-with-sub-path.tsx
@@ -1,0 +1,14 @@
+'use client';
+
+import {usePathname} from "next/navigation";
+import {StatisticalUnitDetailsLink, StatisticalUnitDetailsLinkProps} from "@/components/statistical-unit-details-link";
+
+export function StatisticalUnitDetailsLinkWithSubPath(props: StatisticalUnitDetailsLinkProps) {
+    /* When navigating between units, we want to keep the path the same.
+     * For example, if we are on /legal-units/1/contact, and we click on an establishment,
+     * we want to go to /establishments/2/contact. */
+
+    const pathname = usePathname();
+    const path = pathname.split(/\d{1,10}\//)?.[1] ?? '';
+    return <StatisticalUnitDetailsLink {...props} sub_path={path}/>
+}

--- a/app/src/components/statistical-unit-details-link.tsx
+++ b/app/src/components/statistical-unit-details-link.tsx
@@ -18,7 +18,7 @@ export function StatisticalUnitDetailsLink({id, type, name, className}: Statisti
      * For example, if we are on /legal-units/1/contact, and we click on an establishment,
      * we want to go to /establishments/2/contact.
      */
-    const path = /\d+\/(.+)/.exec(pathname)?.[1] ?? '';
+    const path = /\d+\/([\w\-]+)\/?$/.exec(pathname)?.[1] ?? '';
 
     const href = {
         enterprise_group: `/enterprise-groups/${id}/${path}`,

--- a/app/src/components/statistical-unit-details-link.tsx
+++ b/app/src/components/statistical-unit-details-link.tsx
@@ -1,5 +1,7 @@
+'use client';
 import Link from "next/link";
 import {cn} from "@/lib/utils";
+import {usePathname} from "next/navigation";
 
 interface StatisticalUnitDetailsLinkProps {
     readonly id: number;
@@ -9,13 +11,20 @@ interface StatisticalUnitDetailsLinkProps {
 }
 
 export function StatisticalUnitDetailsLink({id, type, name, className}: StatisticalUnitDetailsLinkProps) {
+    const pathname = usePathname();
 
-    // TODO: Update enterprise link when enterprise details page is implemented
+    /*
+     * When navigating between units, we want to keep the path the same.
+     * For example, if we are on /legal-units/1/contact, and we click on an establishment,
+     * we want to go to /establishments/2/contact.
+     */
+    const path = /\d+\/(.+)/.exec(pathname)?.[1] ?? '';
+
     const href = {
-        enterprise_group: `/enterprise-groups/${id}`,
-        enterprise: `/legal-units/${id}`,
-        legal_unit: `/legal-units/${id}`,
-        establishment: `/establishments/${id}`
+        enterprise_group: `/enterprise-groups/${id}/${path}`,
+        enterprise: `/legal-units/${id}/${path}`,
+        legal_unit: `/legal-units/${id}/${path}`,
+        establishment: `/establishments/${id}/${path}`
     }[type];
 
     return (

--- a/app/src/components/statistical-unit-details-link.tsx
+++ b/app/src/components/statistical-unit-details-link.tsx
@@ -1,34 +1,24 @@
-'use client';
 import Link from "next/link";
 import {cn} from "@/lib/utils";
-import {usePathname} from "next/navigation";
 
-interface StatisticalUnitDetailsLinkProps {
+export interface StatisticalUnitDetailsLinkProps {
     readonly id: number;
     readonly type: 'enterprise_group' | 'enterprise' | 'legal_unit' | 'establishment';
     readonly name: string;
     readonly className?: string;
+    readonly sub_path?: string;
 }
 
-export function StatisticalUnitDetailsLink({id, type, name, className}: StatisticalUnitDetailsLinkProps) {
-    const pathname = usePathname();
-
-    /*
-     * When navigating between units, we want to keep the path the same.
-     * For example, if we are on /legal-units/1/contact, and we click on an establishment,
-     * we want to go to /establishments/2/contact.
-     */
-    const path = /\d+\/([\w\-]+)\/?$/.exec(pathname)?.[1] ?? '';
-
+export function StatisticalUnitDetailsLink({id, type, name, className, sub_path}: StatisticalUnitDetailsLinkProps) {
     const href = {
-        enterprise_group: `/enterprise-groups/${id}/${path}`,
-        enterprise: `/legal-units/${id}/${path}`,
-        legal_unit: `/legal-units/${id}/${path}`,
-        establishment: `/establishments/${id}/${path}`
+        enterprise_group: `/enterprise-groups/${id}`,
+        enterprise: `/legal-units/${id}`,
+        legal_unit: `/legal-units/${id}`,
+        establishment: `/establishments/${id}`
     }[type];
 
     return (
-        <Link href={href} className={cn("font-medium", className)}>
+        <Link href={sub_path ? `${href}/${sub_path}` : href} className={cn("font-medium", className)}>
             {name}
         </Link>
     )

--- a/app/src/components/statistical-unit-details/details-page.tsx
+++ b/app/src/components/statistical-unit-details/details-page.tsx
@@ -4,7 +4,7 @@ import {Separator} from "@/components/ui/separator";
 export const DetailsPage = ({title, subtitle, children}: {
   readonly title: string,
   readonly subtitle: string,
-  readonly children: ReactNode
+  readonly children?: ReactNode
 }) => (
   <div className="space-y-6">
     <div>

--- a/app/src/components/statistical-unit-hierarchy/topology-item.tsx
+++ b/app/src/components/statistical-unit-hierarchy/topology-item.tsx
@@ -1,31 +1,31 @@
 import {ReactNode} from "react";
 import {cn} from "@/lib/utils";
 import {StatisticalUnitIcon} from "@/components/statistical-unit-icon";
-import {StatisticalUnitDetailsLink} from "@/components/statistical-unit-details-link";
+import {StatisticalUnitDetailsLinkWithSubPath} from "@/components/statistical-unit-details-link-with-sub-path";
 
 interface TopologyItemProps {
-  readonly active?: boolean;
-  readonly children?: ReactNode;
-  readonly type: 'legal_unit' | 'establishment' | 'enterprise' | 'enterprise_group';
-  readonly unit: {
-    id: number;
-    name: string;
-  }
+    readonly active?: boolean;
+    readonly children?: ReactNode;
+    readonly type: 'legal_unit' | 'establishment' | 'enterprise' | 'enterprise_group';
+    readonly unit: {
+        id: number;
+        name: string;
+    }
 }
 
 export function TopologyItem({unit: {id, name}, type, active, children}: TopologyItemProps) {
-  return (
-    <li className="mb-2">
-      <div className={cn("flex items-center gap-2", active ? "underline" : "")}>
-        <StatisticalUnitIcon type={type}/>
-        <StatisticalUnitDetailsLink
-          id={id}
-          type={type}
-          name={name}
-          className="font-normal flex-1 whitespace-nowrap overflow-hidden overflow-ellipsis"
-        />
-      </div>
-      {children && <ul className="pl-4 pt-4">{children}</ul>}
-    </li>
-  )
+    return (
+        <li className="mb-2">
+            <div className={cn("flex items-center gap-2", active ? "underline" : "")}>
+                <StatisticalUnitIcon type={type}/>
+                <StatisticalUnitDetailsLinkWithSubPath
+                    id={id}
+                    type={type}
+                    name={name}
+                    className="font-normal flex-1 whitespace-nowrap overflow-hidden overflow-ellipsis"
+                />
+            </div>
+            {children && <ul className="pl-4 pt-4">{children}</ul>}
+        </li>
+    )
 }

--- a/app/src/components/statistical-unit-hierarchy/topology.tsx
+++ b/app/src/components/statistical-unit-hierarchy/topology.tsx
@@ -11,7 +11,7 @@ export function Topology({hierarchy, unitId, unitType}: TopologyProps) {
   return (
     <ul className="text-xs">
       {
-        hierarchy?.enterprise.legal_unit.map((legalUnit) => (
+        hierarchy?.enterprise?.legal_unit.map((legalUnit) => (
           <TopologyItem
             key={legalUnit.id}
             unit={legalUnit}


### PR DESCRIPTION
Keep sub path when navigating between units in hierarchy to allow user to stay in one context while navigating organizations within the hierarchy.

For instance, when viewing the contact information of one establishment, it is good UX to keep the contact information tab active when switching to and from another establishment / legal unit.