### PR TITLE
[ui] Colorize unit type filter and set human-readable values

### DIFF
--- a/app/src/app/search/components/conditional-value-badge.tsx
+++ b/app/src/app/search/components/conditional-value-badge.tsx
@@ -20,7 +20,7 @@ export function ConditionalValueBadge({condition, value}: ConditionalValue) {
     const prefix = resolveSymbol(condition)
 
     return (
-        <Badge variant="secondary" className="rounded-sm px-1 font-normal">
+        <Badge variant="secondary" className="rounded-sm px-2 font-normal">
             {prefix} {value}
         </Badge>
     )

--- a/app/src/app/search/components/options-filter.tsx
+++ b/app/src/app/search/components/options-filter.tsx
@@ -7,6 +7,7 @@ import * as React from "react";
 import {Separator} from "@/components/ui/separator";
 import {Badge} from "@/components/ui/badge";
 import type {SearchFilterOption} from "@/app/search/search.types";
+import {cn} from "@/lib/utils";
 
 interface ITableFilterProps {
   title: string,
@@ -30,7 +31,7 @@ export function OptionsFilter({title, options = [], selectedValues, onToggle, on
                 options
                   .filter((option) => selectedValues.includes(option.value))
                   .map((option) => (
-                    <Badge variant="secondary" key={option.value} className="rounded-sm px-1 font-normal">
+                    <Badge variant="secondary" key={option.value} className={cn("rounded-sm px-2 font-normal", option.className)}>
                       {option.humanReadableValue ?? option.value}
                     </Badge>
                   ))

--- a/app/src/app/search/hooks/use-filter.ts
+++ b/app/src/app/search/hooks/use-filter.ts
@@ -67,9 +67,24 @@ export const useFilter = ({regions = [], activityCategories = [], statisticalVar
       label: "Type",
       name: "unit_type",
       options: [
-          {label: "Legal Unit", value: "legal_unit"},
-          {label: "Establishment", value: "establishment"},
-          {label: "Enterprise", value: "enterprise"},
+        {
+          label: "Legal Unit",
+          value: "legal_unit",
+          humanReadableValue: "Legal Unit",
+          className: "bg-lime-200"
+        },
+        {
+          label: "Establishment",
+          value: "establishment",
+          humanReadableValue: "Establishment",
+          className: "bg-indigo-200"
+        },
+        {
+          label: "Enterprise",
+          value: "enterprise",
+          humanReadableValue: "Enterprise",
+          className: "bg-amber-200"
+        }
       ],
       selected: ["enterprise"],
       postgrestQuery: ({selected}) => selected.length ? `in.(${selected.join(',')})` : null

--- a/app/src/app/search/search.types.ts
+++ b/app/src/app/search/search.types.ts
@@ -6,6 +6,7 @@ export type SearchFilterOption = {
     readonly label: string
     readonly value: string
     readonly humanReadableValue?: string
+    readonly className?: string
 }
 
 export type SearchFilter = {


### PR DESCRIPTION
This PR builds on the latest changes on statistical units search where each statistical unit type is given a separate icon and color. 

In this PR we colorize the selected filter values and we also display the unit type the same way we do in the search result. Example: "Legal Unit" not "legal_unit".