### PR TITLE
[ui] Define tailwind color aliases for various unit types

### DIFF
--- a/app/src/app/search/hooks/use-filter.ts
+++ b/app/src/app/search/hooks/use-filter.ts
@@ -71,19 +71,19 @@ export const useFilter = ({regions = [], activityCategories = [], statisticalVar
           label: "Legal Unit",
           value: "legal_unit",
           humanReadableValue: "Legal Unit",
-          className: "bg-lime-200"
+          className: "bg-legal_unit-200"
         },
         {
           label: "Establishment",
           value: "establishment",
           humanReadableValue: "Establishment",
-          className: "bg-indigo-200"
+          className: "bg-establishment-200"
         },
         {
           label: "Enterprise",
           value: "enterprise",
           humanReadableValue: "Enterprise",
-          className: "bg-amber-200"
+          className: "bg-enterprise-200"
         }
       ],
       selected: ["enterprise"],

--- a/app/src/components/statistical-unit-icon.tsx
+++ b/app/src/components/statistical-unit-icon.tsx
@@ -8,11 +8,11 @@ interface TopologyItemIconProps {
 export function StatisticalUnitIcon({type, size = 16}: TopologyItemIconProps) {
     switch (type) {
         case "legal_unit":
-            return <Building size={size} className="stroke-gray-700 fill-lime-200"/>
+            return <Building size={size} className="stroke-gray-700 fill-legal_unit-200"/>
         case "establishment":
-            return <Store size={size} className="stroke-gray-700 fill-indigo-200"/>
+            return <Store size={size} className="stroke-gray-700 fill-establishment-200"/>
         case "enterprise":
-            return <Building2 size={size} className="stroke-gray-700 fill-amber-200"/>
+            return <Building2 size={size} className="stroke-gray-700 fill-enterprise-200"/>
         default:
             return null
     }

--- a/app/tailwind.config.ts
+++ b/app/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type {Config} from "tailwindcss"
+import colors from "tailwindcss/colors";
 
 const config: Config = {
   darkMode: ["class"],
@@ -32,6 +33,11 @@ const config: Config = {
         "accordion-down": "accordion-down 0.2s ease-out",
         "accordion-up": "accordion-up 0.2s ease-out",
       },
+      colors: {
+        enterprise: colors.amber,
+        legal_unit: colors.lime,
+        establishment: colors.indigo,
+      }
     },
   },
   plugins: [require("tailwindcss-animate")],


### PR DESCRIPTION
By providing tailwind color aliases in taiwind config it makes it easier to control the color theme and colors are not spread around the code base.