### PR TITLE
[ui] Keep search filter state in URL search param

### DIFF
--- a/app/src/app/reports/search-link.tsx
+++ b/app/src/app/reports/search-link.tsx
@@ -1,7 +1,7 @@
 import {DrillDownPoint} from "@/app/reports/types/drill-down";
 import {Button} from "@/components/ui/button";
 import Link from "next/link";
-import {PHYSICAL_REGION_PATH, PRIMARY_ACTIVITY_CATEGORY_PATH} from "@/app/search/constants";
+import {SearchFilterName} from "@/app/search/search.types";
 
 export const SearchLink = ({region, activityCategory}: {
   readonly region: DrillDownPoint | null,
@@ -11,11 +11,13 @@ export const SearchLink = ({region, activityCategory}: {
   const searchParams = new URLSearchParams();
 
   if (region) {
-    searchParams.set(PHYSICAL_REGION_PATH, region.path);
+    const name: SearchFilterName = 'physical_region_path'
+    searchParams.set(name, region.path);
   }
 
   if (activityCategory) {
-    searchParams.set(PRIMARY_ACTIVITY_CATEGORY_PATH, activityCategory.path);
+    const name: SearchFilterName = 'primary_activity_category_path'
+    searchParams.set(name, activityCategory.path);
   }
 
   return (

--- a/app/src/app/search/components/search-result-table.tsx
+++ b/app/src/app/search/components/search-result-table.tsx
@@ -5,14 +5,14 @@ import {StatisticalUnitDetailsLink} from "@/components/statistical-unit-details-
 import {StatisticalUnitIcon} from "@/components/statistical-unit-icon";
 
 interface TableProps {
-  readonly searchResult: SearchResult
+  readonly searchResult?: SearchResult
   readonly regions: Tables<'region_used'>[]
   readonly activityCategories: Tables<'activity_category_available'>[]
 }
 
 export default function SearchResultTable(
   {
-    searchResult: {statisticalUnits},
+    searchResult: { statisticalUnits } = { statisticalUnits: [], count: 0 },
     regions = [],
     activityCategories = [],
   }: TableProps) {

--- a/app/src/app/search/components/search.tsx
+++ b/app/src/app/search/components/search.tsx
@@ -4,13 +4,11 @@ import {Tables} from "@/lib/database.types";
 import SearchResultTable from "@/app/search/components/search-result-table";
 import useSearch from "@/app/search/hooks/use-search";
 import {useFilter} from "@/app/search/hooks/use-filter";
-import type {SearchResult} from "@/app/search/search.types";
 import {ExportCSVLink} from "@/app/search/components/search-export-csv-link";
 import SaveSearchButton from "@/app/search/components/search-save-button";
 import useUpdatedUrlSearchParams from "@/app/search/hooks/use-updated-url-search-params";
 
 interface SearchProps {
-    readonly initialSearchResult: SearchResult
     readonly regions: Tables<"region_used">[]
     readonly activityCategories: Tables<"activity_category_available">[]
     readonly statisticalVariables: Tables<"stat_definition">[]
@@ -18,14 +16,13 @@ interface SearchProps {
 
 export default function Search(
     {
-        initialSearchResult,
         regions = [],
         activityCategories,
         statisticalVariables
     }: SearchProps
 ) {
     const [filters, searchFilterDispatch] = useFilter({activityCategories, regions, statisticalVariables})
-    const {search: { data: searchResult}, searchParams} = useSearch(filters, initialSearchResult)
+    const {search: { data: searchResult}, searchParams} = useSearch(filters)
 
     useUpdatedUrlSearchParams(filters)
 
@@ -33,7 +30,7 @@ export default function Search(
         <section className="space-y-3">
             <TableToolbar dispatch={searchFilterDispatch} filters={filters} />
             <div className="rounded-md border">
-                <SearchResultTable regions={regions} activityCategories={activityCategories} searchResult={searchResult ?? initialSearchResult}/>
+                <SearchResultTable regions={regions} activityCategories={activityCategories} searchResult={searchResult}/>
             </div>
             <div className="flex justify-between text-xs text-gray-500 items-center">
                 <span className="indent-2.5">

--- a/app/src/app/search/components/search.tsx
+++ b/app/src/app/search/components/search.tsx
@@ -7,6 +7,7 @@ import {useFilter} from "@/app/search/hooks/use-filter";
 import type {SearchResult} from "@/app/search/search.types";
 import {ExportCSVLink} from "@/app/search/components/search-export-csv-link";
 import SaveSearchButton from "@/app/search/components/search-save-button";
+import useUpdatedUrlSearchParams from "@/app/search/hooks/use-updated-url-search-params";
 
 interface SearchProps {
     readonly initialSearchResult: SearchResult
@@ -25,6 +26,8 @@ export default function Search(
 ) {
     const [filters, searchFilterDispatch] = useFilter({activityCategories, regions, statisticalVariables})
     const {search: { data: searchResult}, searchParams} = useSearch(filters, initialSearchResult)
+
+    useUpdatedUrlSearchParams(filters)
 
     return (
         <section className="space-y-3">

--- a/app/src/app/search/components/search.tsx
+++ b/app/src/app/search/components/search.tsx
@@ -7,21 +7,23 @@ import {useFilter} from "@/app/search/hooks/use-filter";
 import {ExportCSVLink} from "@/app/search/components/search-export-csv-link";
 import SaveSearchButton from "@/app/search/components/search-save-button";
 import useUpdatedUrlSearchParams from "@/app/search/hooks/use-updated-url-search-params";
+import {SearchFilter} from "@/app/search/search.types";
 
 interface SearchProps {
     readonly regions: Tables<"region_used">[]
     readonly activityCategories: Tables<"activity_category_available">[]
     readonly statisticalVariables: Tables<"stat_definition">[]
+    readonly filters: [SearchFilter[], SearchFilter[]]
 }
 
 export default function Search(
     {
         regions = [],
         activityCategories,
-        statisticalVariables
+        filters: initialFilters
     }: SearchProps
 ) {
-    const [filters, searchFilterDispatch] = useFilter({activityCategories, regions, statisticalVariables})
+    const [filters, searchFilterDispatch] = useFilter(initialFilters)
     const {search: { data: searchResult}, searchParams} = useSearch(filters)
 
     useUpdatedUrlSearchParams(filters)

--- a/app/src/app/search/constants.ts
+++ b/app/src/app/search/constants.ts
@@ -1,2 +1,0 @@
-export const PHYSICAL_REGION_PATH = 'physical_region_path';
-export const PRIMARY_ACTIVITY_CATEGORY_PATH = 'primary_activity_category_path';

--- a/app/src/app/search/create-filters.ts
+++ b/app/src/app/search/create-filters.ts
@@ -1,25 +1,30 @@
-import {FilterOptions, SearchFilter, SearchFilterCondition} from "@/app/search/search.types";
-import {PHYSICAL_REGION_PATH, PRIMARY_ACTIVITY_CATEGORY_PATH} from "@/app/search/constants";
+import {FilterOptions, SearchFilter, SearchFilterCondition, SearchFilterName} from "@/app/search/search.types";
 
 export function createFilters(opts: FilterOptions, urlSearchParams: URLSearchParams): [SearchFilter[], SearchFilter[]] {
+  const unit_type: SearchFilterName = 'unit_type'
+  const physical_region_path: SearchFilterName = 'physical_region_path'
+  const primary_activity_category_path: SearchFilterName = 'primary_activity_category_path'
+  const tax_reg_ident: SearchFilterName = 'tax_reg_ident'
+  const search: SearchFilterName = 'search'
+  const defaultUnitTypeFilterValue = 'enterprise'
   const standardFilters: SearchFilter[] = [
     {
       type: "search",
       label: "Name",
       // Search is a vector field of name indexed for fast full text search.
-      name: "search",
-      selected: urlSearchParams?.has('search') ? [urlSearchParams?.get('search') as string] : [],
+      name: search,
+      selected: urlSearchParams?.has(search) ? [urlSearchParams?.get(search) as string] : [],
     },
     {
       type: "search",
       label: "Tax ID",
-      name: "tax_reg_ident",
-      selected: urlSearchParams?.has('tax_reg_ident') ? [urlSearchParams?.get('tax_reg_ident') as string] : [],
+      name: tax_reg_ident,
+      selected: urlSearchParams?.has(tax_reg_ident) ? [urlSearchParams?.get(tax_reg_ident) as string] : [],
     },
     {
       type: "options",
       label: "Type",
-      name: "unit_type",
+      name: unit_type,
       options: [
         {
           label: "Legal Unit",
@@ -40,11 +45,11 @@ export function createFilters(opts: FilterOptions, urlSearchParams: URLSearchPar
           className: "bg-enterprise-200"
         }
       ],
-      selected: urlSearchParams?.get('unit_type')?.split(',') ?? ["enterprise"],
+      selected: urlSearchParams?.get(unit_type)?.split(',') ?? [defaultUnitTypeFilterValue],
     },
     {
       type: "radio",
-      name: "physical_region_path",
+      name: physical_region_path,
       label: "Region",
       options: opts.regions.map(({code, path, name}) => (
         {
@@ -53,11 +58,11 @@ export function createFilters(opts: FilterOptions, urlSearchParams: URLSearchPar
           humanReadableValue: `${code} ${name}`
         }
       )),
-      selected: urlSearchParams?.has(PHYSICAL_REGION_PATH) ? [urlSearchParams?.get(PHYSICAL_REGION_PATH) as string] : [],
+      selected: urlSearchParams?.has(physical_region_path) ? [urlSearchParams?.get(physical_region_path) as string] : [],
     },
     {
       type: "radio",
-      name: "primary_activity_category_path",
+      name: primary_activity_category_path,
       label: "Activity Category",
       options: opts.activityCategories.map(({code, path, name}) => (
         {
@@ -66,10 +71,11 @@ export function createFilters(opts: FilterOptions, urlSearchParams: URLSearchPar
           humanReadableValue: `${code} ${name}`
         }
       )),
-      selected: urlSearchParams?.has(PRIMARY_ACTIVITY_CATEGORY_PATH) ? [urlSearchParams?.get(PRIMARY_ACTIVITY_CATEGORY_PATH) as string] : [],
+      selected: urlSearchParams?.has(primary_activity_category_path) ? [urlSearchParams?.get(primary_activity_category_path) as string] : [],
     }
   ];
 
+  // @ts-ignore - we do not know what will be the statistical variable names
   const statisticalVariableFilters: SearchFilter[] = opts.statisticalVariables.map(variable => {
     const conditionalSearchParam = urlSearchParams?.get(variable.code)
     const [condition, value] = conditionalSearchParam?.split('.') ?? []

--- a/app/src/app/search/create-filters.ts
+++ b/app/src/app/search/create-filters.ts
@@ -1,0 +1,87 @@
+import {FilterOptions, SearchFilter, SearchFilterCondition} from "@/app/search/search.types";
+import {PHYSICAL_REGION_PATH, PRIMARY_ACTIVITY_CATEGORY_PATH} from "@/app/search/constants";
+
+export function createFilters(opts: FilterOptions, urlSearchParams: URLSearchParams): [SearchFilter[], SearchFilter[]] {
+  const standardFilters: SearchFilter[] = [
+    {
+      type: "search",
+      label: "Name",
+      // Search is a vector field of name indexed for fast full text search.
+      name: "search",
+      selected: urlSearchParams?.has('search') ? [urlSearchParams?.get('search') as string] : [],
+    },
+    {
+      type: "search",
+      label: "Tax ID",
+      name: "tax_reg_ident",
+      selected: urlSearchParams?.has('tax_reg_ident') ? [urlSearchParams?.get('tax_reg_ident') as string] : [],
+    },
+    {
+      type: "options",
+      label: "Type",
+      name: "unit_type",
+      options: [
+        {
+          label: "Legal Unit",
+          value: "legal_unit",
+          humanReadableValue: "Legal Unit",
+          className: "bg-legal_unit-200"
+        },
+        {
+          label: "Establishment",
+          value: "establishment",
+          humanReadableValue: "Establishment",
+          className: "bg-establishment-200"
+        },
+        {
+          label: "Enterprise",
+          value: "enterprise",
+          humanReadableValue: "Enterprise",
+          className: "bg-enterprise-200"
+        }
+      ],
+      selected: urlSearchParams?.get('unit_type')?.split(',') ?? ["enterprise"],
+    },
+    {
+      type: "radio",
+      name: "physical_region_path",
+      label: "Region",
+      options: opts.regions.map(({code, path, name}) => (
+        {
+          label: `${code} ${name}`,
+          value: path as string,
+          humanReadableValue: `${code} ${name}`
+        }
+      )),
+      selected: urlSearchParams?.has(PHYSICAL_REGION_PATH) ? [urlSearchParams?.get(PHYSICAL_REGION_PATH) as string] : [],
+    },
+    {
+      type: "radio",
+      name: "primary_activity_category_path",
+      label: "Activity Category",
+      options: opts.activityCategories.map(({code, path, name}) => (
+        {
+          label: `${code} ${name}`,
+          value: path as string,
+          humanReadableValue: `${code} ${name}`
+        }
+      )),
+      selected: urlSearchParams?.has(PRIMARY_ACTIVITY_CATEGORY_PATH) ? [urlSearchParams?.get(PRIMARY_ACTIVITY_CATEGORY_PATH) as string] : [],
+    }
+  ];
+
+  const statisticalVariableFilters: SearchFilter[] = opts.statisticalVariables.map(variable => {
+    const conditionalSearchParam = urlSearchParams?.get(variable.code)
+    const [condition, value] = conditionalSearchParam?.split('.') ?? []
+
+    return {
+      type: "conditional",
+      name: variable.code,
+      label: variable.name,
+      selected: value ? [value] : [],
+      condition: condition ? condition as SearchFilterCondition : undefined
+    }
+  });
+
+  return [standardFilters, statisticalVariableFilters]
+}

--- a/app/src/app/search/hooks/__tests__/use-search.test.ts
+++ b/app/src/app/search/hooks/__tests__/use-search.test.ts
@@ -1,4 +1,4 @@
-import {generateFTSQuery} from "@/app/search/hooks/use-filter";
+import {generateFTSQuery} from "@/app/search/hooks/use-search";
 
 describe("generateFTSQuery", () => {
   it('formats a simple query correctly', () => {

--- a/app/src/app/search/hooks/use-filter.ts
+++ b/app/src/app/search/hooks/use-filter.ts
@@ -1,8 +1,7 @@
-import {Tables} from "@/lib/database.types";
 import {useReducer} from "react";
-import type {SearchFilter, SearchFilterActions, SearchFilterCondition} from "@/app/search/search.types";
+import type {FilterOptions, SearchFilter, SearchFilterActions} from "@/app/search/search.types";
 import {useSearchParams} from "next/navigation";
-import {PHYSICAL_REGION_PATH, PRIMARY_ACTIVITY_CATEGORY_PATH} from "@/app/search/constants";
+import {createFilters} from "@/app/search/create-filters";
 
 function searchFilterReducer(state: SearchFilter[], action: SearchFilterActions): SearchFilter[] {
   switch (action.type) {
@@ -38,102 +37,8 @@ function searchFilterReducer(state: SearchFilter[], action: SearchFilterActions)
   }
 }
 
-interface FilterOptions {
-  activityCategories: Tables<"activity_category_available">[],
-  regions: Tables<"region_used">[]
-  statisticalVariables: Tables<"stat_definition">[]
-}
-
-export const useFilter = ({regions = [], activityCategories = [], statisticalVariables = []}: FilterOptions) => {
-  const urlSearchParams = useSearchParams()
-  const standardFilters: SearchFilter[] = [
-    {
-      type: "search",
-      label: "Name",
-      // Search is a vector field of name indexed for fast full text search.
-      name: "search",
-      selected: urlSearchParams?.has('search') ? [urlSearchParams?.get('search') as string] : [],
-      postgrestQuery: ({selected}) => generateFTSQuery(selected[0])
-    },
-    {
-      type: "search",
-      label: "Tax ID",
-      name: "tax_reg_ident",
-      selected: urlSearchParams?.has('tax_reg_ident') ? [urlSearchParams?.get('tax_reg_ident') as string] : [],
-      postgrestQuery: ({selected}) => selected[0] ? `eq.${selected[0]}` : null
-    },
-    {
-      type: "options",
-      label: "Type",
-      name: "unit_type",
-      options: [
-        {
-          label: "Legal Unit",
-          value: "legal_unit",
-          humanReadableValue: "Legal Unit",
-          className: "bg-legal_unit-200"
-        },
-        {
-          label: "Establishment",
-          value: "establishment",
-          humanReadableValue: "Establishment",
-          className: "bg-establishment-200"
-        },
-        {
-          label: "Enterprise",
-          value: "enterprise",
-          humanReadableValue: "Enterprise",
-          className: "bg-enterprise-200"
-        }
-      ],
-      selected: urlSearchParams?.get('unit_type')?.split(',') ?? ["enterprise"],
-      postgrestQuery: ({selected}) => selected.length ? `in.(${selected.join(',')})` : null
-    },
-    {
-      type: "radio",
-      name: "physical_region_path",
-      label: "Region",
-      options: regions.map(({code, path, name}) => (
-        {
-          label: `${code} ${name}`,
-          value: path as string,
-          humanReadableValue: `${code} ${name}`
-        }
-      )),
-      selected: urlSearchParams?.has(PHYSICAL_REGION_PATH) ? [urlSearchParams?.get(PHYSICAL_REGION_PATH) as string] : [],
-      postgrestQuery: ({selected}) => selected.length ? `cd.${selected.join()}` : null
-    },
-    {
-      type: "radio",
-      name: "primary_activity_category_path",
-      label: "Activity Category",
-      options: activityCategories.map(({code, path, name}) => (
-        {
-          label: `${code} ${name}`,
-          value: path as string,
-          humanReadableValue: `${code} ${name}`
-        }
-      )),
-      selected: urlSearchParams?.has(PRIMARY_ACTIVITY_CATEGORY_PATH) ? [urlSearchParams?.get(PRIMARY_ACTIVITY_CATEGORY_PATH) as string] : [],
-      postgrestQuery: ({selected}) => selected.length ? `cd.${selected.join()}` : null
-    }
-  ];
-
-  const statisticalVariableFilters: SearchFilter[] = statisticalVariables.map(variable => {
-    const conditionalSearchParam = urlSearchParams?.get(variable.code)
-    const [condition, value] = conditionalSearchParam?.split('.') ?? []
-
-    return {
-      type: "conditional",
-      name: variable.code,
-      label: variable.name,
-      selected: value ? [value] : [],
-      condition: condition ? condition as SearchFilterCondition : undefined,
-      postgrestQuery: ({condition, selected}: SearchFilter) =>
-        condition && selected.length ? `${condition}.${selected.join(',')}` : null
-    }
-  });
-
+export const useFilter = (filters: [SearchFilter[], SearchFilter[]]) => {
+  const [standardFilters, statisticalVariableFilters] = filters
   return useReducer(searchFilterReducer, [...standardFilters, ...statisticalVariableFilters])
 }
 

--- a/app/src/app/search/hooks/use-filter.ts
+++ b/app/src/app/search/hooks/use-filter.ts
@@ -1,7 +1,5 @@
 import {useReducer} from "react";
-import type {FilterOptions, SearchFilter, SearchFilterActions} from "@/app/search/search.types";
-import {useSearchParams} from "next/navigation";
-import {createFilters} from "@/app/search/create-filters";
+import type {SearchFilter, SearchFilterActions} from "@/app/search/search.types";
 
 function searchFilterReducer(state: SearchFilter[], action: SearchFilterActions): SearchFilter[] {
   switch (action.type) {
@@ -42,13 +40,3 @@ export const useFilter = (filters: [SearchFilter[], SearchFilter[]]) => {
   return useReducer(searchFilterReducer, [...standardFilters, ...statisticalVariableFilters])
 }
 
-export function generateFTSQuery(prompt: string = ""): string | null {
-  const cleanedPrompt = prompt.trim().toLowerCase();
-  const isNegated = (word: string) => new RegExp(`\\-\\b(${word})\\b`).test(cleanedPrompt)
-  const uniqueWordsInPrompt = new Set(cleanedPrompt.match(/\b\w+\b/g) ?? []);
-  const tsQuery = [...uniqueWordsInPrompt]
-    .map(word => isNegated(word) ? `!'${word}':*` : `'${word}':*`)
-    .join(' & ');
-
-  return tsQuery ? `fts(simple).${tsQuery}` : null;
-}

--- a/app/src/app/search/hooks/use-search.ts
+++ b/app/src/app/search/hooks/use-search.ts
@@ -1,17 +1,16 @@
 import useSWR, {Fetcher} from "swr";
 import type {SearchFilter, SearchResult} from "@/app/search/search.types";
-import {generateFTSQuery} from "@/app/search/hooks/use-filter";
 
 const fetcher: Fetcher<SearchResult, string> = (...args) => fetch(...args).then(res => res.json())
 
 export default function useSearch(filters: SearchFilter[]) {
-    const searchParams = filters
-        .map(f => [f.name, generatePostgrestQuery(f)])
-        .filter(([, query]) => !!query)
-        .reduce((params, [name, query]) => {
-            params.set(name!, query!);
-            return params;
-        }, new URLSearchParams());
+  const searchParams = filters
+    .map(f => [f.name, generatePostgrestQuery(f)])
+    .filter(([, query]) => !!query)
+    .reduce((params, [name, query]) => {
+      params.set(name!, query!);
+      return params;
+    }, new URLSearchParams());
 
   const search = useSWR<SearchResult>(`/search/api?${searchParams}`, fetcher, {
     keepPreviousData: true,
@@ -21,8 +20,22 @@ export default function useSearch(filters: SearchFilter[]) {
   return {search, searchParams}
 }
 
+export function generateFTSQuery(prompt: string = ""): string | null {
+  const cleanedPrompt = prompt.trim().toLowerCase();
+  const isNegated = (word: string) => new RegExp(`\\-\\b(${word})\\b`).test(cleanedPrompt)
+  const uniqueWordsInPrompt = new Set(cleanedPrompt.match(/\b\w+\b/g) ?? []);
+  const tsQuery = [...uniqueWordsInPrompt]
+    .map(word => isNegated(word) ? `!'${word}':*` : `'${word}':*`)
+    .join(' & ');
+
+  return tsQuery ? `fts(simple).${tsQuery}` : null;
+}
+
 const generatePostgrestQuery = (f: SearchFilter) => {
-  // TODO: generate type safe filter name type to ensure all branches are covered
+  if (f.type === 'conditional') {
+    return f.condition && f.selected.length ? `${f.condition}.${f.selected[0]}` : null
+  }
+
   switch (f.name) {
     case 'search':
       return generateFTSQuery(f.selected[0])
@@ -34,8 +47,6 @@ const generatePostgrestQuery = (f: SearchFilter) => {
       return f.selected.length ? `cd.${f.selected.join()}` : null
     case 'primary_activity_category_path':
       return f.selected.length ? `cd.${f.selected.join()}` : null
-    case 'conditional':
-      return f.condition && f.selected.length ? `${f.condition}.${f.selected[0]}` : null
     default:
       return null
   }

--- a/app/src/app/search/hooks/use-search.ts
+++ b/app/src/app/search/hooks/use-search.ts
@@ -3,7 +3,7 @@ import type {SearchFilter, SearchResult} from "@/app/search/search.types";
 
 const fetcher: Fetcher<SearchResult, string> = (...args) => fetch(...args).then(res => res.json())
 
-export default function useSearch(filters: SearchFilter[], fallbackData: SearchResult) {
+export default function useSearch(filters: SearchFilter[]) {
     const searchParams = filters
         .map(f => [f.name, f.postgrestQuery(f)])
         .filter(([, query]) => !!query)
@@ -14,8 +14,7 @@ export default function useSearch(filters: SearchFilter[], fallbackData: SearchR
 
   const search = useSWR<SearchResult>(`/search/api?${searchParams}`, fetcher, {
     keepPreviousData: true,
-    revalidateOnFocus: false,
-    fallbackData
+    revalidateOnFocus: false
   })
 
   return {search, searchParams}

--- a/app/src/app/search/hooks/use-search.ts
+++ b/app/src/app/search/hooks/use-search.ts
@@ -1,11 +1,12 @@
 import useSWR, {Fetcher} from "swr";
 import type {SearchFilter, SearchResult} from "@/app/search/search.types";
+import {generateFTSQuery} from "@/app/search/hooks/use-filter";
 
 const fetcher: Fetcher<SearchResult, string> = (...args) => fetch(...args).then(res => res.json())
 
 export default function useSearch(filters: SearchFilter[]) {
     const searchParams = filters
-        .map(f => [f.name, f.postgrestQuery(f)])
+        .map(f => [f.name, generatePostgrestQuery(f)])
         .filter(([, query]) => !!query)
         .reduce((params, [name, query]) => {
             params.set(name!, query!);
@@ -18,4 +19,24 @@ export default function useSearch(filters: SearchFilter[]) {
   })
 
   return {search, searchParams}
+}
+
+const generatePostgrestQuery = (f: SearchFilter) => {
+  // TODO: generate type safe filter name type to ensure all branches are covered
+  switch (f.name) {
+    case 'search':
+      return generateFTSQuery(f.selected[0])
+    case 'tax_reg_ident':
+      return f.selected[0] ? `eq.${f.selected[0]}` : null
+    case 'unit_type':
+      return f.selected.length ? `in.(${f.selected.join(',')})` : null
+    case 'physical_region_path':
+      return f.selected.length ? `cd.${f.selected.join()}` : null
+    case 'primary_activity_category_path':
+      return f.selected.length ? `cd.${f.selected.join()}` : null
+    case 'conditional':
+      return f.condition && f.selected.length ? `${f.condition}.${f.selected[0]}` : null
+    default:
+      return null
+  }
 }

--- a/app/src/app/search/hooks/use-updated-url-search-params.ts
+++ b/app/src/app/search/hooks/use-updated-url-search-params.ts
@@ -1,0 +1,15 @@
+import {useEffect} from "react";
+import {SearchFilter} from "@/app/search/search.types";
+
+export default function useUpdatedUrlSearchParams(filters: SearchFilter[]) {
+  useEffect(() => {
+    const urlSearchParams = filters
+      .filter(f => f.selected?.length > 0 && !!f.selected[0])
+      .reduce((acc, f) => {
+        acc.set(f.name, f.condition ? `${f.condition}.${f.selected[0]}` : f.selected.join(","));
+        return acc;
+      }, new URLSearchParams());
+
+    window.history.pushState({}, '', `?${urlSearchParams}`)
+  }, [filters]);
+}

--- a/app/src/app/search/page.tsx
+++ b/app/src/app/search/page.tsx
@@ -8,12 +8,6 @@ export const metadata: Metadata = {
 
 export default async function SearchPage() {
     const client = createClient();
-    const statisticalUnitPromise = client
-        .from('statistical_unit')
-        .select('name, tax_reg_ident, primary_activity_category_path, unit_id, unit_type, physical_region_path', {count: 'exact'})
-        .in('unit_type', ['enterprise'])
-        .order('tax_reg_ident', {ascending: false})
-        .limit(10);
 
     const regionPromise = client
         .from('region_used')
@@ -29,20 +23,14 @@ export default async function SearchPage() {
         .order('priority', {ascending: true});
 
     const [
-        {data: statisticalUnits, count, error: statisticalUnitsError},
         {data: regions, error: regionsError},
         {data: activityCategories, error: activityCategoriesError},
         {data: statisticalVariables}
     ] = await Promise.all([
-        statisticalUnitPromise,
         regionPromise,
         activityCategoryPromise,
         statDefinitionPromise
     ]);
-
-    if (statisticalUnitsError) {
-        console.error('⚠️failed to fetch statistical units', statisticalUnitsError);
-    }
 
     if (regionsError) {
         console.error('⚠️failed to fetch regions', regionsError);
@@ -59,7 +47,6 @@ export default async function SearchPage() {
                 regions={regions ?? []}
                 activityCategories={activityCategories ?? []}
                 statisticalVariables={statisticalVariables ?? []}
-                initialSearchResult={{statisticalUnits: statisticalUnits ?? [], count: count ?? 0}}
             />
         </main>
     )

--- a/app/src/app/search/page.tsx
+++ b/app/src/app/search/page.tsx
@@ -2,11 +2,13 @@ import {createClient} from "@/lib/supabase/server";
 import Search from "@/app/search/components/search";
 import {Metadata} from "next";
 
+import {createFilters} from "@/app/search/create-filters";
+
 export const metadata: Metadata = {
     title: "StatBus | Search statistical units"
 }
 
-export default async function SearchPage() {
+export default async function SearchPage({ searchParams }: { readonly searchParams: URLSearchParams }) {
     const client = createClient();
 
     const regionPromise = client
@@ -40,6 +42,12 @@ export default async function SearchPage() {
         console.error('⚠️failed to fetch activity categories', activityCategoriesError);
     }
 
+    const filters = createFilters({
+        activityCategories: activityCategories ?? [],
+        regions: regions ?? [],
+        statisticalVariables: statisticalVariables ?? []
+    }, new URLSearchParams(searchParams));
+
     return (
         <main className="flex flex-col py-8 px-2 md:py-24 mx-auto w-full max-w-5xl">
             <h1 className="font-medium text-xl text-center mb-12">Search for statistical units</h1>
@@ -47,6 +55,7 @@ export default async function SearchPage() {
                 regions={regions ?? []}
                 activityCategories={activityCategories ?? []}
                 statisticalVariables={statisticalVariables ?? []}
+                filters={filters}
             />
         </main>
     )

--- a/app/src/app/search/search.types.ts
+++ b/app/src/app/search/search.types.ts
@@ -8,7 +8,6 @@ export type SearchFilterName =
   | "unit_type"
   | "physical_region_path"
   | "primary_activity_category_path"
-  | string
 
 export type SearchFilterOption = {
   readonly label: string

--- a/app/src/app/search/search.types.ts
+++ b/app/src/app/search/search.types.ts
@@ -2,38 +2,46 @@ import {Tables} from "@/lib/database.types";
 
 export type SearchFilterCondition = "eq" | "gt" | "lt" | "in" | "ilike"
 
+export type SearchFilterName =
+  "search"
+  | "tax_reg_ident"
+  | "unit_type"
+  | "physical_region_path"
+  | "primary_activity_category_path"
+  | string
+
 export type SearchFilterOption = {
-    readonly label: string
-    readonly value: string
-    readonly humanReadableValue?: string
-    readonly className?: string
+  readonly label: string
+  readonly value: string
+  readonly humanReadableValue?: string
+  readonly className?: string
 }
 
 export type SearchFilter = {
-    readonly type: "options" | "radio" | "conditional" | "search"
-    readonly name: string
-    readonly label: string
-    readonly options?: SearchFilterOption[]
-    readonly selected: string[]
-    readonly condition?: SearchFilterCondition
+  readonly type: "options" | "radio" | "conditional" | "search"
+  readonly name: SearchFilterName
+  readonly label: string
+  readonly options?: SearchFilterOption[]
+  readonly selected: string[]
+  readonly condition?: SearchFilterCondition
 }
 
 export type SearchResult = {
-    statisticalUnits: Partial<Tables<"statistical_unit">>[]
-    count: number
+  statisticalUnits: Partial<Tables<"statistical_unit">>[]
+  count: number
 }
 
 export interface ConditionalValue {
-    condition: SearchFilterCondition
-    value: string,
+  condition: SearchFilterCondition
+  value: string,
 }
 
 interface ToggleOption {
-    type: "toggle_option",
-    payload: {
-        name: string,
-        value: string
-    }
+  type: "toggle_option",
+  payload: {
+    name: string,
+    value: string
+  }
 }
 
 interface ToggleRadioOption {
@@ -45,12 +53,12 @@ interface ToggleRadioOption {
 }
 
 interface SetCondition {
-    type: "set_condition",
-    payload: {
-        name: string,
-        value: string,
-        condition: SearchFilterCondition
-    }
+  type: "set_condition",
+  payload: {
+    name: string,
+    value: string,
+    condition: SearchFilterCondition
+  }
 }
 
 interface SetSearch {
@@ -62,14 +70,14 @@ interface SetSearch {
 }
 
 interface Reset {
-    type: "reset",
-    payload: {
-        name: string
-    }
+  type: "reset",
+  payload: {
+    name: string
+  }
 }
 
 interface ResetAll {
-    type: "reset_all"
+  type: "reset_all"
 }
 
 export type SearchFilterActions = ToggleOption | ToggleRadioOption | SetCondition | SetSearch | Reset | ResetAll

--- a/app/src/app/search/search.types.ts
+++ b/app/src/app/search/search.types.ts
@@ -16,7 +16,6 @@ export type SearchFilter = {
     readonly options?: SearchFilterOption[]
     readonly selected: string[]
     readonly condition?: SearchFilterCondition
-    readonly postgrestQuery: (filter: SearchFilter) => string | null
 }
 
 export type SearchResult = {
@@ -74,3 +73,9 @@ interface ResetAll {
 }
 
 export type SearchFilterActions = ToggleOption | ToggleRadioOption | SetCondition | SetSearch | Reset | ResetAll
+
+export interface FilterOptions {
+  activityCategories: Tables<"activity_category_available">[],
+  regions: Tables<"region_used">[]
+  statisticalVariables: Tables<"stat_definition">[]
+}


### PR DESCRIPTION
To let the user navigate to and from the search page / unit details page without resetting the search filter we persist all filters in the URL. This also has the benefit of making the search sharable so that our users can share their search with their co-workers.

Since the initial filters are now available from the URL the filter component can be rendered on the server initially which gives a more responsive feel to it.

This PR also does some changes to improve the type safety when setting filter and search query parameters.