### PR TITLE
[ui] Call replaceState when setting search filter query params

### DIFF
--- a/app/src/app/search/hooks/use-updated-url-search-params.ts
+++ b/app/src/app/search/hooks/use-updated-url-search-params.ts
@@ -10,6 +10,6 @@ export default function useUpdatedUrlSearchParams(filters: SearchFilter[]) {
         return acc;
       }, new URLSearchParams());
 
-    window.history.pushState({}, '', `?${urlSearchParams}`)
+    window.history.replaceState({}, '', `?${urlSearchParams}`)
   }, [filters]);
 }


### PR DESCRIPTION
We do not want to create another history object on stack, but rather replace the existing one.