### PR TITLE
[ui] Display employee count in search result table

### DIFF
--- a/app/src/app/search/api/route.ts
+++ b/app/src/app/search/api/route.ts
@@ -9,7 +9,7 @@ export async function GET(request: Request) {
     }
 
     if (!searchParams.has('select')) {
-        searchParams.set('select', 'name, tax_reg_ident, primary_activity_category_path, unit_id, unit_type, physical_region_path')
+        searchParams.set('select', '*')
     }
 
     if (!searchParams.has('limit')) {

--- a/app/src/app/search/components/search-result-table.tsx
+++ b/app/src/app/search/components/search-result-table.tsx
@@ -29,6 +29,7 @@ export default function SearchResultTable(
         <TableRow>
           <TableHead>Name</TableHead>
           <TableHead className="text-left">Region</TableHead>
+          <TableHead className="text-right">Employees</TableHead>
           <TableHead className="text-right">Activity Category Code</TableHead>
         </TableRow>
       </TableHeader>
@@ -41,7 +42,8 @@ export default function SearchResultTable(
                 tax_reg_ident,
                 name,
                 physical_region_path,
-                primary_activity_category_path
+                primary_activity_category_path,
+                employees
               } = unit;
               return (
                 <TableRow key={`${unit_type}_${unit_id}`}>
@@ -60,6 +62,9 @@ export default function SearchResultTable(
                   </TableCell>
                   <TableCell className="text-left py-1">
                     {getRegionByPath(physical_region_path)?.name}
+                  </TableCell>
+                  <TableCell className="text-right py-1">
+                    {employees ?? '-'}
                   </TableCell>
                   <TableCell className="text-right py-1 px-4">
                     {getActivityCategoryByPath(primary_activity_category_path)?.code}

--- a/app/src/app/search/search.types.ts
+++ b/app/src/app/search/search.types.ts
@@ -26,7 +26,7 @@ export type SearchFilter = {
 }
 
 export type SearchResult = {
-  statisticalUnits: Partial<Tables<"statistical_unit">>[]
+  statisticalUnits: Tables<"statistical_unit">[]
   count: number
 }
 


### PR DESCRIPTION
This PR will expand the search result table with a column for employee count.

It also updates the api route returning search results to include all attributes of a statistical unit.