### PR TITLE
[ui] Expand hierarchy view

### DIFF
--- a/app/src/app/enterprises/[id]/@header/default.tsx
+++ b/app/src/app/enterprises/[id]/@header/default.tsx
@@ -1,0 +1,10 @@
+import {DetailsPageHeader} from "@/components/statistical-unit-details/details-page-header";
+import {getEnterpriseById} from "@/app/enterprises/[id]/enterprise-requests";
+
+export default async function HeaderSlot({params: {id}}: { readonly params: { id: string } }) {
+  const unit = await getEnterpriseById(id);
+  const name = `Enterprise ${unit?.id}`;
+  return (
+    <DetailsPageHeader name={name} className="bg-enterprise-50 border-indigo-100"/>
+  )
+}

--- a/app/src/app/enterprises/[id]/@nav/default.tsx
+++ b/app/src/app/enterprises/[id]/@nav/default.tsx
@@ -1,0 +1,11 @@
+import {SidebarLink, SidebarNav} from "@/components/sidebar-nav";
+
+export default function NavSlot({params: {id}}: { readonly params: { id: string } }) {
+    return (
+        <SidebarNav>
+            <SidebarLink href={`/enterprises/${id}`}>General info</SidebarLink>
+            <SidebarLink href={`/enterprises/${id}/contact`}>Contact</SidebarLink>
+            <SidebarLink href={`/enterprises/${id}/inspect`}>Inspect</SidebarLink>
+        </SidebarNav>
+    )
+}

--- a/app/src/app/enterprises/[id]/@topology/default.tsx
+++ b/app/src/app/enterprises/[id]/@topology/default.tsx
@@ -5,9 +5,6 @@ import {StatisticalUnitHierarchy} from "@/components/statistical-unit-hierarchy/
 export default async function StatisticalUnitHierarchySlot({params: {id}}: { readonly params: { id: string } }) {
     const statisticalUnitId = parseInt(id, 10);
     const client = createClient();
-
-    // TODO: update database types and remove ts-ignore
-    // @ts-ignore
     const {data: hierarchy, error} = await client.rpc('statistical_unit_hierarchy', {
         unit_id: statisticalUnitId,
         unit_type: 'enterprise'

--- a/app/src/app/enterprises/[id]/@topology/default.tsx
+++ b/app/src/app/enterprises/[id]/@topology/default.tsx
@@ -1,0 +1,20 @@
+import {createClient} from "@/lib/supabase/server";
+import {Topology} from "@/components/statistical-unit-hierarchy/topology";
+import {StatisticalUnitHierarchy} from "@/components/statistical-unit-hierarchy/statistical-unit-hierarchy-types";
+
+export default async function StatisticalUnitHierarchySlot({params: {id}}: { readonly params: { id: string } }) {
+    const statisticalUnitId = parseInt(id, 10);
+    const client = createClient();
+
+    // TODO: update database types and remove ts-ignore
+    // @ts-ignore
+    const {data: hierarchy, error} = await client.rpc('statistical_unit_hierarchy', {
+        unit_id: statisticalUnitId,
+        unit_type: 'enterprise'
+    }).returns<StatisticalUnitHierarchy>()
+
+    return error ? null : (
+        <Topology hierarchy={hierarchy} unitId={statisticalUnitId} unitType="enterprise"/>
+    )
+}
+

--- a/app/src/app/enterprises/[id]/[...slug]/page.tsx
+++ b/app/src/app/enterprises/[id]/[...slug]/page.tsx
@@ -1,0 +1,5 @@
+import {redirect, RedirectType} from "next/navigation";
+
+export default function Fallback({params: {id}}: { readonly params: { id: string } }) {
+    redirect(`/enterprises/${id}`, RedirectType.replace)
+}

--- a/app/src/app/enterprises/[id]/contact/page.tsx
+++ b/app/src/app/enterprises/[id]/contact/page.tsx
@@ -1,8 +1,8 @@
-import {notFound} from "next/navigation";
 import {DetailsPage} from "@/components/statistical-unit-details/details-page";
+import {notFound} from "next/navigation";
 import {getEnterpriseById} from "@/app/enterprises/[id]/enterprise-requests";
 
-export default async function EnterpriseDetailsPage({params: {id}}: { readonly params: { id: string } }) {
+export default async function EnterpriseContactPage({params: {id}}: { readonly params: { id: string } }) {
   const unit = await getEnterpriseById(id);
   const name = `Enterprise ${unit?.id}`;
 
@@ -11,10 +11,11 @@ export default async function EnterpriseDetailsPage({params: {id}}: { readonly p
   }
 
   return (
-    <DetailsPage title="General Info" subtitle="General information such as name, sector">
+    <DetailsPage title="Contact Info" subtitle="Contact information such as email, phone, and addresses">
       <p className="bg-gray-50 p-12 text-sm text-center">
-        This section will show general information for {name}
+        This section will show the contact information for {name}
       </p>
     </DetailsPage>
   )
 }
+

--- a/app/src/app/enterprises/[id]/enterprise-requests.ts
+++ b/app/src/app/enterprises/[id]/enterprise-requests.ts
@@ -1,0 +1,11 @@
+import {createClient} from "@/lib/supabase/server";
+
+export async function getEnterpriseById(id: string) {
+  const {data: enterprise} = await createClient()
+    .from("enterprise")
+    .select("*")
+    .eq("id", id)
+    .single()
+
+  return enterprise;
+}

--- a/app/src/app/enterprises/[id]/inspect/page.tsx
+++ b/app/src/app/enterprises/[id]/inspect/page.tsx
@@ -1,0 +1,20 @@
+import DataDump from "@/components/data-dump";
+import {DetailsPage} from "@/components/statistical-unit-details/details-page";
+import {notFound} from "next/navigation";
+import {getEnterpriseById} from "@/app/enterprises/[id]/enterprise-requests";
+
+export default async function EnterpriseInspectionPage({params: {id}}: { readonly params: { id: string } }) {
+  const unit = await getEnterpriseById(id);
+  const name = `Enterprise ${unit?.id}`;
+
+  if (!unit) {
+    notFound()
+  }
+
+  return (
+    <DetailsPage title="Data Dump" subtitle={`This section shows the raw data we have on ${name}`}>
+      <DataDump data={unit}/>
+    </DetailsPage>
+  )
+}
+

--- a/app/src/app/enterprises/[id]/layout.tsx
+++ b/app/src/app/enterprises/[id]/layout.tsx
@@ -1,0 +1,15 @@
+import {Metadata} from "next"
+import {DetailsPageLayout, DetailsPageLayoutProps} from "@/components/statistical-unit-details/details-page-layout";
+
+export const metadata: Metadata = {
+  title: "Details"
+}
+
+export default function SettingsLayout({children, header, topology, nav}: DetailsPageLayoutProps) {
+  return (
+    <DetailsPageLayout header={header} nav={nav} topology={topology}>{children}</DetailsPageLayout>
+  )
+}
+
+
+

--- a/app/src/app/establishments/[id]/@header/default.tsx
+++ b/app/src/app/establishments/[id]/@header/default.tsx
@@ -4,6 +4,6 @@ import {DetailsPageHeader} from "@/components/statistical-unit-details/details-p
 export default async function HeaderSlot({params: {id}}: { readonly params: { id: string } }) {
   const unit = await getEstablishmentById(id);
   return (
-    <DetailsPageHeader name={unit?.name} className="bg-indigo-50 border-indigo-100"/>
+    <DetailsPageHeader name={unit?.name} className="bg-establishment-50 border-indigo-100"/>
   )
 }

--- a/app/src/app/establishments/[id]/@topology/default.tsx
+++ b/app/src/app/establishments/[id]/@topology/default.tsx
@@ -5,9 +5,6 @@ import {StatisticalUnitHierarchy} from "@/components/statistical-unit-hierarchy/
 export default async function StatisticalUnitHierarchySlot({params: {id}}: { readonly params: { id: string } }) {
     const statisticalUnitId = parseInt(id, 10);
     const client = createClient();
-
-    // TODO: update database types and remove ts-ignore
-    // @ts-ignore
     const {data: hierarchy, error} = await client.rpc('statistical_unit_hierarchy', {
         unit_id: statisticalUnitId,
         unit_type: 'establishment'

--- a/app/src/app/establishments/[id]/page.tsx
+++ b/app/src/app/establishments/[id]/page.tsx
@@ -10,7 +10,7 @@ export default async function EstablishmentGeneralInfoPage({params: {id}}: { rea
   }
 
   return (
-    <DetailsPage title="General Info" subtitle="General establishment information such as name, sector">
+    <DetailsPage title="General Info" subtitle="General information such as name, sector">
       <p className="bg-gray-50 p-12 text-sm text-center">
         This section will show general information for {unit.name}
       </p>

--- a/app/src/app/legal-units/[id]/@header/default.tsx
+++ b/app/src/app/legal-units/[id]/@header/default.tsx
@@ -4,7 +4,7 @@ import {DetailsPageHeader} from "@/components/statistical-unit-details/details-p
 export default async function HeaderSlot({params: {id}}: { readonly params: { id: string } }) {
   const unit = await getLegalUnitById(id);
   return (
-    <DetailsPageHeader name={unit?.name} className="bg-lime-50 border-lime-100"/>
+    <DetailsPageHeader name={unit?.name} className="bg-legal_unit-50 border-lime-100"/>
   )
 }
 

--- a/app/src/app/legal-units/[id]/@topology/default.tsx
+++ b/app/src/app/legal-units/[id]/@topology/default.tsx
@@ -5,9 +5,6 @@ import {StatisticalUnitHierarchy} from "@/components/statistical-unit-hierarchy/
 export default async function StatisticalUnitHierarchySlot({params: {id}}: { readonly params: { id: string } }) {
     const statisticalUnitId = parseInt(id, 10);
     const client = createClient();
-
-    // TODO: update database types and remove ts-ignore
-    // @ts-ignore
     const {data: hierarchy, error} = await client.rpc('statistical_unit_hierarchy', {
         unit_id: statisticalUnitId,
         unit_type: 'legal_unit'

--- a/app/src/app/search/components/search-result-table.tsx
+++ b/app/src/app/search/components/search-result-table.tsx
@@ -42,7 +42,7 @@ export default function SearchResultTable() {
               return (
                 <TableRow key={`${unit_type}_${unit_id}`}>
                   <TableCell className="px-2 py-2 flex items-center space-x-3 leading-none">
-                    <StatisticalUnitIcon type={unit_type} size={20}/>
+                    <StatisticalUnitIcon type={unit_type} className="w-5"/>
                     <div className="flex flex-col space-y-1.5 flex-1">
                       {
                         unit_type && unit_id && name ? (

--- a/app/src/components/statistical-unit-details-link.tsx
+++ b/app/src/components/statistical-unit-details-link.tsx
@@ -12,7 +12,7 @@ export interface StatisticalUnitDetailsLinkProps {
 export function StatisticalUnitDetailsLink({id, type, name, className, sub_path}: StatisticalUnitDetailsLinkProps) {
     const href = {
         enterprise_group: `/enterprise-groups/${id}`,
-        enterprise: `/legal-units/${id}`,
+        enterprise: `/enterprises/${id}`,
         legal_unit: `/legal-units/${id}`,
         establishment: `/establishments/${id}`
     }[type];

--- a/app/src/components/statistical-unit-hierarchy/topology-item.tsx
+++ b/app/src/components/statistical-unit-hierarchy/topology-item.tsx
@@ -2,30 +2,35 @@ import {ReactNode} from "react";
 import {cn} from "@/lib/utils";
 import {StatisticalUnitIcon} from "@/components/statistical-unit-icon";
 import {StatisticalUnitDetailsLinkWithSubPath} from "@/components/statistical-unit-details-link-with-sub-path";
+import {Asterisk} from "lucide-react";
 
 interface TopologyItemProps {
-    readonly active?: boolean;
-    readonly children?: ReactNode;
-    readonly type: 'legal_unit' | 'establishment' | 'enterprise' | 'enterprise_group';
-    readonly unit: {
-        id: number;
-        name?: string;
-    }
+  readonly active?: boolean;
+  readonly children?: ReactNode;
+  readonly type: 'legal_unit' | 'establishment' | 'enterprise' | 'enterprise_group';
+  readonly primary?: boolean;
+  readonly unit: {
+    id: number;
+    name?: string;
+  }
 }
 
-export function TopologyItem({unit: {id, name}, type, active, children}: TopologyItemProps) {
-    return (
-        <li className="mb-2">
-            <div className={cn("flex items-center gap-2", active ? "underline" : "")}>
-                <StatisticalUnitIcon type={type}/>
-                <StatisticalUnitDetailsLinkWithSubPath
-                    id={id}
-                    type={type}
-                    name={name ?? `${type} ${id}`.toUpperCase()}
-                    className="font-normal flex-1 whitespace-nowrap overflow-hidden overflow-ellipsis"
-                />
-            </div>
-            {children && <ul className="pl-4 pt-4">{children}</ul>}
-        </li>
-    )
+export function TopologyItem({unit: {id, name}, type, active, primary, children}: TopologyItemProps) {
+  return (
+    <li className="mb-2">
+      <div className={cn("flex items-center gap-2", active ? "underline" : "", primary ? '-ml-6' : null)}>
+        {
+          primary ? (<Asterisk className="stroke-gray-700 w-4"/>) : null
+        }
+        <StatisticalUnitIcon type={type} className="w-4"/>
+        <StatisticalUnitDetailsLinkWithSubPath
+          id={id}
+          type={type}
+          name={name ?? `${type} ${id}`.toUpperCase()}
+          className={cn("font-normal flex-1 whitespace-nowrap overflow-hidden overflow-ellipsis leading-none p-0.5")}
+        />
+      </div>
+      {children && <ul className="pl-6 pt-2">{children}</ul>}
+    </li>
+  )
 }

--- a/app/src/components/statistical-unit-hierarchy/topology-item.tsx
+++ b/app/src/components/statistical-unit-hierarchy/topology-item.tsx
@@ -9,7 +9,7 @@ interface TopologyItemProps {
     readonly type: 'legal_unit' | 'establishment' | 'enterprise' | 'enterprise_group';
     readonly unit: {
         id: number;
-        name: string;
+        name?: string;
     }
 }
 
@@ -21,7 +21,7 @@ export function TopologyItem({unit: {id, name}, type, active, children}: Topolog
                 <StatisticalUnitDetailsLinkWithSubPath
                     id={id}
                     type={type}
-                    name={name}
+                    name={name ?? `${type} ${id}`.toUpperCase()}
                     className="font-normal flex-1 whitespace-nowrap overflow-hidden overflow-ellipsis"
                 />
             </div>

--- a/app/src/components/statistical-unit-hierarchy/topology.tsx
+++ b/app/src/components/statistical-unit-hierarchy/topology.tsx
@@ -18,6 +18,7 @@ export function Topology({hierarchy, unitId, unitType}: TopologyProps) {
               unit={legalUnit}
               type="legal_unit"
               active={legalUnit.id === unitId && unitType === 'legal_unit'}
+              primary={legalUnit.primary}
             >
               {legalUnit.establishment.map((establishment) =>
                 <TopologyItem
@@ -25,6 +26,7 @@ export function Topology({hierarchy, unitId, unitType}: TopologyProps) {
                   unit={establishment}
                   active={establishment.id === unitId && unitType === 'establishment'}
                   type="establishment"
+                  primary={establishment.primary}
                 />
               )}
             </TopologyItem>

--- a/app/src/components/statistical-unit-hierarchy/topology.tsx
+++ b/app/src/components/statistical-unit-hierarchy/topology.tsx
@@ -10,25 +10,27 @@ interface TopologyProps {
 export function Topology({hierarchy, unitId, unitType}: TopologyProps) {
   return (
     <ul className="text-xs">
-      {
-        hierarchy?.enterprise?.legal_unit.map((legalUnit) => (
-          <TopologyItem
-            key={legalUnit.id}
-            unit={legalUnit}
-            type="legal_unit"
-            active={legalUnit.id === unitId && unitType === 'legal_unit'}
-          >
-            {legalUnit.establishment.map((establishment) =>
-              <TopologyItem
-                key={establishment.id}
-                unit={establishment}
-                active={establishment.id === unitId && unitType === 'establishment'}
-                type="establishment"
-              />
-            )}
-          </TopologyItem>
-        ))
-      }
+      <TopologyItem type="enterprise" unit={hierarchy?.enterprise}>
+        {
+          hierarchy?.enterprise?.legal_unit.map((legalUnit) => (
+            <TopologyItem
+              key={legalUnit.id}
+              unit={legalUnit}
+              type="legal_unit"
+              active={legalUnit.id === unitId && unitType === 'legal_unit'}
+            >
+              {legalUnit.establishment.map((establishment) =>
+                <TopologyItem
+                  key={establishment.id}
+                  unit={establishment}
+                  active={establishment.id === unitId && unitType === 'establishment'}
+                  type="establishment"
+                />
+              )}
+            </TopologyItem>
+          ))
+        }
+      </TopologyItem>
     </ul>
   )
 }

--- a/app/src/components/statistical-unit-icon.tsx
+++ b/app/src/components/statistical-unit-icon.tsx
@@ -1,18 +1,19 @@
 import {Building, Building2, Store} from "lucide-react";
+import {cn} from "@/lib/utils";
 
 interface TopologyItemIconProps {
     type?: 'legal_unit' | 'establishment' | 'enterprise' | 'enterprise_group' | null;
-    size?: number;
+    className?: string;
 }
 
-export function StatisticalUnitIcon({type, size = 16}: TopologyItemIconProps) {
+export function StatisticalUnitIcon({type, className}: TopologyItemIconProps) {
     switch (type) {
         case "legal_unit":
-            return <Building size={size} className="stroke-gray-700 fill-legal_unit-200"/>
+            return <Building className={cn("stroke-gray-700 fill-legal_unit-200", className)}/>
         case "establishment":
-            return <Store size={size} className="stroke-gray-700 fill-establishment-200"/>
+            return <Store className={cn("stroke-gray-700 fill-establishment-200", className)}/>
         case "enterprise":
-            return <Building2 size={size} className="stroke-gray-700 fill-enterprise-200"/>
+            return <Building2 className={cn("stroke-gray-700 fill-enterprise-200", className)}/>
         default:
             return null
     }


### PR DESCRIPTION
**Work**

- Add routes for _enterprise_ details, like the existing _establishment_ and _legal unit_ detail pages.
- Display enterprise in topology
- Mark establishment and legal_unit if **primary**