### PR TITLE
[ui] Display error message, stack and digest whenever details page fail

### DIFF
--- a/app/src/app/enterprises/[id]/page.tsx
+++ b/app/src/app/enterprises/[id]/page.tsx
@@ -6,7 +6,7 @@ export default async function EnterpriseDetailsPage({params: {id}}: { readonly p
   const {unit, error} = await getEnterpriseById(id)
 
   if (error) {
-    throw error
+    throw new Error(error.message, { cause: error})
   }
 
   if (!unit) {

--- a/app/src/app/establishments/[id]/page.tsx
+++ b/app/src/app/establishments/[id]/page.tsx
@@ -6,7 +6,7 @@ export default async function EstablishmentGeneralInfoPage({params: {id}}: { rea
   const {unit, error} = await getEstablishmentById(id);
 
   if (error) {
-    throw error
+    throw new Error(error.message, { cause: error})
   }
 
   if (!unit) {

--- a/app/src/app/legal-units/[id]/page.tsx
+++ b/app/src/app/legal-units/[id]/page.tsx
@@ -12,7 +12,7 @@ export default async function LegalUnitGeneralInfoPage({params: {id}}: { readonl
   const {unit, error} = await getLegalUnitById(id)
 
   if (error) {
-    throw error
+    throw new Error(error.message, { cause: error})
   }
 
   if (!unit) {

--- a/app/src/components/statistical-unit-details/details-page-error.tsx
+++ b/app/src/components/statistical-unit-details/details-page-error.tsx
@@ -1,5 +1,4 @@
 import {DetailsPage} from "@/components/statistical-unit-details/details-page";
-import DataDump from "@/components/data-dump";
 
 interface ErrorPageParams {
   readonly error: Error & { digest?: string };
@@ -7,8 +6,28 @@ interface ErrorPageParams {
 
 export default function DetailsPageError({error}: ErrorPageParams) {
   return (
-    <DetailsPage title="This is what happened" subtitle="The following error happened while trying to get statistical unit information">
-      <DataDump data={error}/>
+    <DetailsPage
+      title="This is what happened"
+      subtitle="The following error happened while trying to get statistical unit information"
+    >
+      <div className="bg-red-100 p-6 space-y-6">
+        {
+          error.message && <ErrorSection title="Error Message" body={error.message}/>
+        }
+        {
+          error.stack && <ErrorSection title="Stack" body={error.stack}/>
+        }
+        {
+          error.digest && <ErrorSection title="Digest" body={error.digest}/>
+        }
+      </div>
     </DetailsPage>
   )
 }
+
+const ErrorSection = ({title, body}: { title: string, body: string }) => (
+  <div>
+    <h2 className="text-xs font-semibold uppercase mb-0.5">{title}:</h2>
+    <p>{body}</p>
+  </div>
+)


### PR DESCRIPTION
This PR also fixes the error thrown on statistical unit details page. Previously a _PostgrestError_ was rethrown whenever stat unit details fetch failed. This did not serialize on error page. Now we instead throw a new `Error`, passing the postgres error message as message and root cause.