### PR TITLE
[ui] Handle iOS bug where search page fail due to missing regex support

### DIFF
--- a/app/src/app/search/hooks/use-search.ts
+++ b/app/src/app/search/hooks/use-search.ts
@@ -25,18 +25,24 @@ export default function useSearch(filters: SearchFilter[], order: SearchOrder) {
   return {search, searchParams}
 }
 
+let wordBoundaryRegex: RegExp
 
-/*
- *   (?<=^|\P{L}) is a positive lookbehind that asserts the position is at the start of the string ^ or after a non-letter \P{L}.
- *   [\p{L}\p{N}]+ matches one or more letters or numbers, including Unicode characters.
- *   (?=\P{L}|$) is a lookahead that asserts the position is at the end of the string $ or before a non-letter \P{L}.
- */
-const unicodeWordBoundaryPattern = /(?<=^|\P{L})([\p{L}\p{N}]+)(?=\P{L}|$)/gu;
+try {
+  /*
+   *   (?<=^|\P{L}) is a positive lookbehind that asserts the position is at the start of the string ^ or after a non-letter \P{L}.
+   *   [\p{L}\p{N}]+ matches one or more letters or numbers, including Unicode characters.
+   *   (?=\P{L}|$) is a lookahead that asserts the position is at the end of the string $ or before a non-letter \P{L}.
+   */
+  wordBoundaryRegex = new RegExp('(?<=^|\\P{L})[\\p{L}\\p{N}]+(?=\\P{L}|$)', 'gu')
+} catch (e) {
+  console.debug('failed to create regex with unicode word boundaries, falling back to ascii word boundaries')
+  wordBoundaryRegex = /\b\w+\b/g
+}
 
 export function generateFTSQuery(prompt: string = ""): string | null {
   const cleanedPrompt = prompt.trim().toLowerCase();
   const isNegated = (word: string) => new RegExp(`\\-\\b(${word})\\b`).test(cleanedPrompt)
-  const uniqueWordsInPrompt = new Set(cleanedPrompt.match(unicodeWordBoundaryPattern) ?? []);
+  const uniqueWordsInPrompt = new Set(cleanedPrompt.match(wordBoundaryRegex) ?? []);
   const tsQuery = [...uniqueWordsInPrompt]
     .map(word => isNegated(word) ? `!'${word}':*` : `'${word}':*`)
     .join(' & ');


### PR DESCRIPTION
The regex `/(?<=^|\P{L})[\p{L}\p{N}]+(?=\P{L}|$)/gu` is not supported by Safari on iOS. This commit wrap the regex constructor in try/catch and fallback to classic word boundary pattern. This has the side effect that unicode chars will not work on iOS Safari.