### PR TITLE
[ui] Fix erroneous enterprise hierarchy item link

### DIFF
--- a/app/src/components/statistical-unit-hierarchy/topology-item.tsx
+++ b/app/src/components/statistical-unit-hierarchy/topology-item.tsx
@@ -6,58 +6,58 @@ import {Card, CardContent, CardHeader, CardTitle} from "@/components/ui/card";
 import {Asterisk} from "lucide-react";
 
 interface TopologyItemProps {
-    readonly active?: boolean;
-    readonly children?: ReactNode;
-    readonly type: 'legal_unit' | 'establishment' | 'enterprise' | 'enterprise_group';
-    readonly primary?: boolean;
-    readonly unit: LegalUnit | Establishment;
+  readonly active?: boolean;
+  readonly children?: ReactNode;
+  readonly type: 'legal_unit' | 'establishment' | 'enterprise' | 'enterprise_group';
+  readonly id: number;
+  readonly primary?: boolean;
+  readonly unit: LegalUnit | Establishment;
 }
 
-export function TopologyItem({unit, type, active, primary, children}: TopologyItemProps) {
-    const activity = unit.activity?.[0]
-    const location = unit.location?.[0];
-    return (
-        <>
-            <StatisticalUnitDetailsLinkWithSubPath
-                id={unit.id}
-                type={type}
-                className={cn("mb-2 block")}
-            >
-                <Card className="overflow-hidden">
-                    <CardHeader
-                        className={cn("flex flex-row items-center justify-between space-y-0 py-1 px-3 bg-gray-100", active && 'bg-gray-300')}
-                    >
-                        <CardTitle className="text-xs font-medium">{unit.name}</CardTitle>
-                        <div className="flex items-center space-x-1">
-                            {primary && <div title="This is a primary unit"><Asterisk className="h-4"/></div>}
-                            <StatisticalUnitIcon type={type} className="w-4"/>
-                        </div>
-                    </CardHeader>
-                    <CardContent className="topology-item-content pb-2 pt-2 px-3 space-y-3">
-                        <div className="flex justify-between text-center space-x-3">
-                            <TopologyItemInfo className="flex-1" title="Region" value={location?.region?.name}/>
-                            <TopologyItemInfo className="flex-1" title="Country" value={location?.country?.name}/>
-                            <TopologyItemInfo className="flex-1" title="Employees" value={unit.stat_for_unit?.[0].employees}/>
-                        </div>
-                        <TopologyItemInfo title="Activity" value={activity?.activity_category?.name}/>
-                    </CardContent>
-                </Card>
-            </StatisticalUnitDetailsLinkWithSubPath>
-            <ul className="pl-4">{children}</ul>
-        </>
-    )
+export function TopologyItem({id, type, unit, active, primary, children}: TopologyItemProps) {
+  const activity = unit.activity?.[0]
+  const location = unit.location?.[0];
+  return (
+    <>
+      <StatisticalUnitDetailsLinkWithSubPath id={id} type={type} className={cn("mb-2 block")}>
+        <Card className="overflow-hidden">
+          <CardHeader
+            className={cn(
+              "flex flex-row items-center justify-between space-y-0 py-1 px-3 bg-gray-100",
+              active && 'bg-gray-300'
+            )}
+          >
+            <CardTitle className="text-xs font-medium">{unit.name}</CardTitle>
+            <div className="flex items-center space-x-1">
+              {primary && <div title="This is a primary unit"><Asterisk className="h-4"/></div>}
+              <StatisticalUnitIcon type={type} className="w-4"/>
+            </div>
+          </CardHeader>
+          <CardContent className="topology-item-content pb-2 pt-2 px-3 space-y-3">
+            <div className="flex justify-between text-center space-x-3">
+              <TopologyItemInfo className="flex-1" title="Region" value={location?.region?.name}/>
+              <TopologyItemInfo className="flex-1" title="Country" value={location?.country?.name}/>
+              <TopologyItemInfo className="flex-1" title="Employees" value={unit.stat_for_unit?.[0].employees}/>
+            </div>
+            <TopologyItemInfo title="Activity" value={activity?.activity_category?.name}/>
+          </CardContent>
+        </Card>
+      </StatisticalUnitDetailsLinkWithSubPath>
+      <ul className="pl-4">{children}</ul>
+    </>
+  )
 }
 
 interface TopologyItemInfoProps {
-    title: string;
-    value?: string | number;
-    fallbackValue?: string;
-    className?: string;
+  title: string;
+  value?: string | number;
+  fallbackValue?: string;
+  className?: string;
 }
 
 const TopologyItemInfo = ({title, value, fallbackValue = '-', className}: TopologyItemInfoProps) => (
-    <div className={cn("space-y-0 flex flex-col text-left", className)}>
-        <span className="text-xs uppercase font-medium text-gray-500">{title}</span>
-        <span className="text-sm">{value ?? fallbackValue}</span>
-    </div>
+  <div className={cn("space-y-0 flex flex-col text-left", className)}>
+    <span className="text-xs uppercase font-medium text-gray-500">{title}</span>
+    <span className="text-sm">{value ?? fallbackValue}</span>
+  </div>
 )

--- a/app/src/components/statistical-unit-hierarchy/topology.tsx
+++ b/app/src/components/statistical-unit-hierarchy/topology.tsx
@@ -29,6 +29,7 @@ export function Topology({hierarchy, unitId, unitType}: TopologyProps) {
             <ul className={cn('hierarchy', compact && '[&_.topology-item-content]:hidden')}>
                 <TopologyItem
                     type="enterprise"
+                    id={hierarchy.enterprise.id}
                     unit={primaryLegalUnit}
                     active={hierarchy.enterprise.id == unitId && unitType === 'enterprise'}
                 >
@@ -36,17 +37,19 @@ export function Topology({hierarchy, unitId, unitType}: TopologyProps) {
                         hierarchy.enterprise.legal_unit.map((legalUnit) => (
                             <TopologyItem
                                 key={legalUnit.id}
-                                unit={legalUnit}
                                 type="legal_unit"
+                                id={legalUnit.id}
+                                unit={legalUnit}
                                 active={legalUnit.id === unitId && unitType === 'legal_unit'}
                                 primary={legalUnit.primary}
                             >
                                 {legalUnit.establishment?.map((establishment) =>
                                     <TopologyItem
                                         key={establishment.id}
+                                        type="establishment"
+                                        id={establishment.id}
                                         unit={establishment}
                                         active={establishment.id === unitId && unitType === 'establishment'}
-                                        type="establishment"
                                         primary={establishment.primary}
                                     />
                                 )}


### PR DESCRIPTION
**Work:**
- [x] Pass unit ID to hierarchy item
- [x] Use unit ID to compose enterprise / legal_unit / establishment link

This fixes an issue where enterprise link was pointing to /enterprises/:primary-legal-unit-id. This was because all information about the enterprise was resolved from the primary legal unit. This PR adds a new hierarchy item prop ('id') that will be used for setting the statistical unit link correctly