### PR TITLE
[ui] Fix bug in search reducer for conditional filter

### DIFF
--- a/app/src/app/search/search-filter-reducer.ts
+++ b/app/src/app/search/search-filter-reducer.ts
@@ -42,7 +42,11 @@ export function searchFilterReducer(
       const filters = state.filters.map((f) =>
         f.name === name ? { ...f, selected: [value], operator } : f
       );
-      return { ...state, pagination: { ...state.pagination, pageNumber: 1 } };
+      return {
+        ...state,
+        filters,
+        pagination: { ...state.pagination, pageNumber: 1 },
+      };
     }
     case "set_search": {
       const { name, value } = action.payload;


### PR DESCRIPTION
There was an error introduced by a merge that caused the filter to not update whenever a statistical unit filter was updated, such as setting employee count filter.