### PR TITLE
[ui, refactor] Simplify logging API route

### DIFF
--- a/app/src/app/api/logger/route.ts
+++ b/app/src/app/api/logger/route.ts
@@ -1,6 +1,5 @@
 import { NextResponse } from "next/server";
 import { Level, LogEvent } from "pino";
-import { createClient } from "@/lib/supabase/server";
 
 import { createServerLogger } from "@/lib/server-logger";
 
@@ -12,18 +11,8 @@ interface ClientLogRequest {
 
 export async function POST(request: Request) {
   try {
-    const client = createClient();
     const logger = await createServerLogger();
-    const {
-      data: { session },
-    } = await client.auth.getSession();
-
-    const {
-      level = "info",
-      event,
-      location,
-    }: ClientLogRequest = await request.json();
-
+    const { level = "info", event }: ClientLogRequest = await request.json();
     const payload = event.messages
       ?.filter((message) => typeof message === "object")
       ?.reduce((acc, message) => {
@@ -33,10 +22,8 @@ export async function POST(request: Request) {
     logger[level](
       {
         ...payload,
-        location,
         reporter: "browser",
         useragent: request.headers.get("user-agent"),
-        user: session?.user.email,
       },
       event.messages[event.messages.length - 1]
     );

--- a/app/src/lib/client-logger.ts
+++ b/app/src/lib/client-logger.ts
@@ -12,7 +12,7 @@ const logger = pino({
             headers: {
               "Content-Type": "application/json",
             },
-            body: JSON.stringify({ level, event, location }),
+            body: JSON.stringify({ level, event }),
           });
         } catch (e) {
           console.error("failed to send log to server", e);


### PR DESCRIPTION
Some logging meta info is provided under the hood by the server logger instance. Because of this, we can simplify the logging API route.

- Email of logged-in user is provided by the server logger
- URL is resolved from referer header in server logger. The location object can therefore be omitted from the logging API route.