### PR TITLE
[ui] Split statistical units count by unit type

### DIFF
--- a/app/src/app/reports/search-link.tsx
+++ b/app/src/app/reports/search-link.tsx
@@ -21,6 +21,8 @@ export const SearchLink = ({
     searchParams.set(name, activityCategory.path);
   }
 
+  searchParams.set("unit_type", "enterprise,legal_unit,establishment");
+
   return (
     <Button asChild>
       <Link href={searchParams.size ? `/search?${searchParams}` : "/search"}>

--- a/app/src/app/search/filters/unit-type-search-filter.ts
+++ b/app/src/app/search/filters/unit-type-search-filter.ts
@@ -28,10 +28,6 @@ export const createUnitTypeSearchFilter = (
         className: "bg-enterprise-100",
       },
     ],
-    selected: unitType?.split(",") ?? [
-      "legal_unit",
-      "establishment",
-      "enterprise",
-    ],
+    selected: unitType?.split(",") ?? ["enterprise"],
   };
 };


### PR DESCRIPTION
**Work:**
- Update dashboard to show unit count by type (enterprise, legal units and establishments)
- Set default unit_type search filter to _enterprise_

![Screenshot 2024-03-27 at 11 53 20](https://github.com/statisticsnorway/statbus/assets/937001/5060a48c-3723-400e-80f2-aefd02f2d33e)
