### PR TITLE
[ui] Implement Time Context for reports / drill-down page

### DIFF
--- a/app/src/app/api/reports/route.ts
+++ b/app/src/app/api/reports/route.ts
@@ -3,24 +3,7 @@ import { setupAuthorizedFetchFn } from "@/lib/supabase/request-helper";
 
 export async function GET(request: Request) {
   const { searchParams: requestParams } = new URL(request.url);
-
-  const params = new URLSearchParams();
-
-  if (requestParams.has("unit_type")) {
-    params.set("unit_type", requestParams.get("unit_type") as string);
-  }
-
-  if (requestParams.has("region_path")) {
-    params.set("region_path", requestParams.get("region_path") as string);
-  }
-
-  if (requestParams.has("activity_category_path")) {
-    params.set(
-      "activity_category_path",
-      requestParams.get("activity_category_path") as string
-    );
-  }
-
+  const params = new URLSearchParams(requestParams);
   const authFetch = setupAuthorizedFetchFn();
   const response = await authFetch(
     `${process.env.SUPABASE_URL}/rest/v1/rpc/statistical_unit_facet_drilldown?${params}`,

--- a/app/src/app/reports/statbus-chart.tsx
+++ b/app/src/app/reports/statbus-chart.tsx
@@ -53,30 +53,38 @@ export default function StatBusChart(props: { readonly drillDown: DrillDown }) {
             className="space-y-8"
           >
             <div className="space-y-6 bg-gray-50 p-4">
-              <BreadCrumb
-                topLevelText="All Regions"
-                points={drillDown.breadcrumb.region}
-                selected={region}
-                onSelect={setRegion}
-              />
-              <DrillDownChart
-                points={drillDown.available.region}
-                onSelect={setRegion}
-                variable={statisticalVariable.value}
-              />
+              {drillDown && (
+                <>
+                  <BreadCrumb
+                    topLevelText="All Regions"
+                    points={drillDown.breadcrumb.region}
+                    selected={region}
+                    onSelect={setRegion}
+                  />
+                  <DrillDownChart
+                    points={drillDown.available.region}
+                    onSelect={setRegion}
+                    variable={statisticalVariable.value}
+                  />
+                </>
+              )}
             </div>
             <div className="bg-gray-50 p-6">
-              <BreadCrumb
-                topLevelText="All Activity Categories"
-                points={drillDown.breadcrumb.activity_category}
-                selected={activityCategory}
-                onSelect={setActivityCategory}
-              />
-              <DrillDownChart
-                points={drillDown.available.activity_category}
-                onSelect={setActivityCategory}
-                variable={statisticalVariable.value}
-              />
+              {drillDown && (
+                <>
+                  <BreadCrumb
+                    topLevelText="All Activity Categories"
+                    points={drillDown.breadcrumb.activity_category}
+                    selected={activityCategory}
+                    onSelect={setActivityCategory}
+                  />
+                  <DrillDownChart
+                    points={drillDown.available.activity_category}
+                    onSelect={setActivityCategory}
+                    variable={statisticalVariable.value}
+                  />
+                </>
+              )}
             </div>
           </TabsContent>
         ))}

--- a/app/src/app/reports/use-drill-down-data.tsx
+++ b/app/src/app/reports/use-drill-down-data.tsx
@@ -1,37 +1,40 @@
 "use client";
 import { DrillDown, DrillDownPoint } from "@/app/reports/types/drill-down";
-import { useEffect, useState } from "react";
-import logger from "@/lib/client-logger";
+import { useState } from "react";
+import { useTimeContext } from "@/app/use-time-context";
+import useSWR from "swr";
 
 export const useDrillDownData = (initialDrillDown: DrillDown) => {
-  const [drillDown, setDrillDown] = useState<DrillDown>(initialDrillDown);
+  const { selectedPeriod } = useTimeContext();
   const [region, setRegion] = useState<DrillDownPoint | null>(null);
   const [activityCategory, setActivityCategory] =
     useState<DrillDownPoint | null>(null);
 
-  useEffect(() => {
-    (async () => {
-      const params = new URLSearchParams();
+  const urlSearchParams = new URLSearchParams();
 
-      if (region?.path) {
-        params.set("region_path", region?.path);
-      }
+  if (region?.path) {
+    urlSearchParams.set("region_path", region?.path);
+  }
 
-      if (activityCategory?.path) {
-        params.set("activity_category_path", activityCategory?.path);
-      }
+  if (activityCategory?.path) {
+    urlSearchParams.set("activity_category_path", activityCategory?.path);
+  }
 
-      try {
-        const res = await fetch(`/api/reports?${params}`);
-        setDrillDown(await res.json());
-      } catch (e) {
-        logger.error(e, "failed to fetch statistical unit drill down data");
-      }
-    })();
-  }, [region, activityCategory]);
+  if (selectedPeriod?.valid_on) {
+    urlSearchParams.set("valid_on", selectedPeriod.valid_on);
+  }
+
+  const swrResponse = useSWR<DrillDown>(
+    `/api/reports?${urlSearchParams}`,
+    (url: string) => fetch(url).then((res) => res.json()),
+    {
+      fallbackData: initialDrillDown,
+      keepPreviousData: true,
+    }
+  );
 
   return {
-    drillDown,
+    drillDown: swrResponse.data,
     region,
     setRegion,
     activityCategory,

--- a/app/src/app/time-context-provider.tsx
+++ b/app/src/app/time-context-provider.tsx
@@ -1,35 +1,16 @@
 "use client";
-import { ReactNode, useEffect, useMemo, useState } from "react";
-import logger from "@/lib/client-logger";
+import { ReactNode, useMemo, useState } from "react";
 import { TimeContext } from "@/app/time-context";
 import type { Period } from "@/app/types";
+import useRelativePeriods from "@/app/use-relative-periods";
 
 interface TimeContextProviderProps {
   readonly children: ReactNode;
 }
 
 export default function TimeContextProvider(props: TimeContextProviderProps) {
-  const [periods, setPeriods] = useState<Period[]>([]);
+  const periods = useRelativePeriods();
   const [selectedPeriod, setSelectedPeriod] = useState<Period | null>(null);
-
-  useEffect(() => {
-    (async () => {
-      try {
-        const response = await fetch("/api/relative-periods");
-
-        if (
-          response.ok &&
-          response.headers.get("content-type") === "application/json"
-        ) {
-          const data = await response.json();
-          setPeriods(data);
-          setSelectedPeriod(data[0]);
-        }
-      } catch (e) {
-        logger.error(e, "failed to fetch relative periods");
-      }
-    })();
-  }, []);
 
   const value = useMemo(
     () => ({ periods, selectedPeriod, setSelectedPeriod }),

--- a/app/src/app/use-relative-periods.ts
+++ b/app/src/app/use-relative-periods.ts
@@ -1,0 +1,27 @@
+import logger from "@/lib/client-logger";
+import { useEffect, useState } from "react";
+import { Period } from "@/app/types";
+
+export default function useRelativePeriods() {
+  const [periods, setPeriods] = useState<Period[]>([]);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const response = await fetch("/api/relative-periods");
+
+        if (
+          response.ok &&
+          response.headers.get("content-type") === "application/json"
+        ) {
+          const data = await response.json();
+          setPeriods(data);
+        }
+      } catch (e) {
+        logger.error(e, "failed to fetch relative periods");
+      }
+    })();
+  }, []);
+
+  return periods;
+}

--- a/app/src/components/time-context-selector.tsx
+++ b/app/src/components/time-context-selector.tsx
@@ -16,6 +16,7 @@ import {
   CommandList,
 } from "@/components/ui/command";
 import { useTimeContext } from "@/app/use-time-context";
+import { useEffect, useState } from "react";
 
 export default function TimeContextSelector({
   className,
@@ -24,7 +25,12 @@ export default function TimeContextSelector({
   readonly className?: string;
   readonly title?: string;
 }) {
+  const [visible, setVisible] = useState(false);
   const { selectedPeriod, periods, setSelectedPeriod } = useTimeContext();
+
+  useEffect(() => {
+    setVisible(true);
+  }, []);
 
   return (
     <Popover>
@@ -34,11 +40,11 @@ export default function TimeContextSelector({
           className={cn(
             "space-x-2 transition-opacity border-dashed duration-500 bg-transparent",
             className,
-            !selectedPeriod ? "opacity-0" : "opacity-100"
+            visible ? "opacity-100" : "opacity-0"
           )}
         >
           <CalendarClock className="mr-2 h-4 w-4" />
-          {selectedPeriod?.name}
+          {selectedPeriod?.name ?? title}
         </Button>
       </PopoverTrigger>
       <PopoverContent


### PR DESCRIPTION
### Summary
This PR will add time context support on the reports / drill-down page.


### Work
- [x] Extract period data fetching into custom react hook `useRelativePeriods`, thus simplifying the `TimeContextProvider`
- [x] Remove default behavior of selecting the first period in data response. We need a more robust solution for this. This PR will set the default selected period to `null`. The user will have to make a conscious decision about the time context. 
- [x] Implement time context on reports / drill-down page
- [x] Sort out double chart rendering on reports / drill-down page