### PR TITLE
[ui] Restrict priveleged menu actions

### DIFF
--- a/app/src/app/layout.tsx
+++ b/app/src/app/layout.tsx
@@ -1,12 +1,12 @@
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
-import "./globals.css";
-import React, { Suspense } from "react";
+import "@/app/globals.css";
+import { Suspense } from "react";
 import Navbar, { NavbarSkeleton } from "@/components/navbar";
 import { cn } from "@/lib/utils";
 import { CommandPalette } from "@/components/command-palette/command-palette";
 import { Toaster } from "@/components/ui/toaster";
-import Footer from "@/components/footer";
+import Footer, { FooterSkeleton } from "@/components/footer";
 import GlobalErrorReporter from "@/app/global-error-reporter";
 import TimeContextProvider from "@/app/time-context-provider";
 
@@ -37,7 +37,9 @@ export default function RootLayout({
           {children}
           <CommandPalette />
           <Toaster />
-          <Footer />
+          <Suspense fallback={<FooterSkeleton />}>
+            <Footer />
+          </Suspense>
           <GlobalErrorReporter />
         </TimeContextProvider>
       </body>

--- a/app/src/app/layout.tsx
+++ b/app/src/app/layout.tsx
@@ -1,8 +1,8 @@
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import "./globals.css";
-import React from "react";
-import Navbar from "@/components/navbar";
+import React, { Suspense } from "react";
+import Navbar, { NavbarSkeleton } from "@/components/navbar";
 import { cn } from "@/lib/utils";
 import { CommandPalette } from "@/components/command-palette/command-palette";
 import { Toaster } from "@/components/ui/toaster";
@@ -31,7 +31,9 @@ export default function RootLayout({
         )}
       >
         <TimeContextProvider>
-          <Navbar />
+          <Suspense fallback={<NavbarSkeleton />}>
+            <Navbar />
+          </Suspense>
           {children}
           <CommandPalette />
           <Toaster />

--- a/app/src/components/footer.tsx
+++ b/app/src/components/footer.tsx
@@ -3,14 +3,19 @@ import { Separator } from "@/components/ui/separator";
 import Link from "next/link";
 import { Github, Globe } from "lucide-react";
 import { SSBLogo } from "@/components/ssb-logo";
+import { createClient } from "@/lib/supabase/server";
 
-export default function Footer() {
+export default async function Footer() {
+  const supabase = createClient();
+  const session = await supabase.auth.getSession();
   return (
     <footer className="border-t-2 border-gray-100 bg-ssb-dark">
       <div className="mx-auto max-w-screen-xl space-y-10 p-6 lg:p-24">
         <div className="flex items-center justify-between space-x-2">
           <SSBLogo className="h-8 lg:h-12 w-auto" />
-          <CommandPaletteTriggerButton className="text-white bg-transparent max-lg:hidden" />
+          {session.data.session?.user && (
+            <CommandPaletteTriggerButton className="text-white bg-transparent max-lg:hidden" />
+          )}
         </div>
         <Separator className="bg-gray-200" />
         <div className="flex justify-between text-gray-500">

--- a/app/src/components/footer.tsx
+++ b/app/src/components/footer.tsx
@@ -5,12 +5,25 @@ import { Github, Globe } from "lucide-react";
 import { SSBLogo } from "@/components/ssb-logo";
 import { createClient } from "@/lib/supabase/server";
 
-export default async function Footer() {
-  const supabase = createClient();
-  const session = await supabase.auth.getSession();
+export function FooterSkeleton() {
   return (
     <footer className="border-t-2 border-gray-100 bg-ssb-dark">
       <div className="mx-auto max-w-screen-xl space-y-10 p-6 lg:p-24">
+        <div className="flex items-center justify-between space-x-2">
+          <SSBLogo className="h-8 lg:h-12 w-auto" />
+        </div>
+      </div>
+    </footer>
+  );
+}
+
+export default async function Footer() {
+  const supabase = createClient();
+  const session = await supabase.auth.getSession();
+
+  return (
+    <footer className="border-t-2 border-gray-100 bg-ssb-dark">
+      <div className="mx-auto max-w-screen-xl space-y-12 p-6 lg:p-24">
         <div className="flex items-center justify-between space-x-2">
           <SSBLogo className="h-8 lg:h-12 w-auto" />
           {session.data.session?.user && (

--- a/app/src/components/navbar.tsx
+++ b/app/src/components/navbar.tsx
@@ -7,8 +7,11 @@ import { cn } from "@/lib/utils";
 import { buttonVariants } from "@/components/ui/button";
 import { CommandPaletteTriggerMobileMenuButton } from "@/components/command-palette/command-palette-trigger-button";
 import TimeContextSelector from "@/components/time-context-selector";
+import { createClient } from "@/lib/supabase/server";
 
-export default function Navbar() {
+export default async function Navbar() {
+  const supabase = createClient();
+  const session = await supabase.auth.getSession();
   return (
     <header className="bg-ssb-dark text-white">
       <div className="mx-auto flex max-w-screen-xl items-center justify-between gap-4 p-2 lg:px-4">
@@ -21,31 +24,33 @@ export default function Navbar() {
             className="h-8"
           />
         </a>
-        <div className="flex-1 space-x-3 flex items-center justify-end">
-          <TimeContextSelector />
-          <Link
-            href="/reports"
-            className={cn(
-              buttonVariants({ variant: "ghost", size: "sm" }),
-              "space-x-2 hidden lg:flex"
-            )}
-          >
-            <BarChartHorizontal size={16} />
-            <span>Reports</span>
-          </Link>
-          <Link
-            href="/search"
-            className={cn(
-              buttonVariants({ variant: "ghost", size: "sm" }),
-              "space-x-2 hidden lg:flex"
-            )}
-          >
-            <Search size={16} />
-            <span>Statistical Units</span>
-          </Link>
-          <ProfileAvatar className="w-8 h-8 text-ssb-dark hidden lg:flex" />
-          <CommandPaletteTriggerMobileMenuButton className="lg:hidden" />
-        </div>
+        {session.data.session?.user && (
+          <div className="flex-1 space-x-3 flex items-center justify-end">
+            <TimeContextSelector />
+            <Link
+              href="/reports"
+              className={cn(
+                buttonVariants({ variant: "ghost", size: "sm" }),
+                "space-x-2 hidden lg:flex"
+              )}
+            >
+              <BarChartHorizontal size={16} />
+              <span>Reports</span>
+            </Link>
+            <Link
+              href="/search"
+              className={cn(
+                buttonVariants({ variant: "ghost", size: "sm" }),
+                "space-x-2 hidden lg:flex"
+              )}
+            >
+              <Search size={16} />
+              <span>Statistical Units</span>
+            </Link>
+            <ProfileAvatar className="w-8 h-8 text-ssb-dark hidden lg:flex" />
+            <CommandPaletteTriggerMobileMenuButton className="lg:hidden" />
+          </div>
+        )}
       </div>
     </header>
   );

--- a/app/src/components/navbar.tsx
+++ b/app/src/components/navbar.tsx
@@ -9,6 +9,16 @@ import { CommandPaletteTriggerMobileMenuButton } from "@/components/command-pale
 import TimeContextSelector from "@/components/time-context-selector";
 import { createClient } from "@/lib/supabase/server";
 
+export function NavbarSkeleton() {
+  return (
+    <header className="bg-ssb-dark text-white">
+      <div className="mx-auto flex max-w-screen-xl items-center justify-between gap-4 p-2 lg:px-4">
+        <Image src={logo} alt="StatBus Logo" className="h-10 w-10" />
+      </div>
+    </header>
+  );
+}
+
 export default async function Navbar() {
   const supabase = createClient();
   const session = await supabase.auth.getSession();
@@ -16,13 +26,7 @@ export default async function Navbar() {
     <header className="bg-ssb-dark text-white">
       <div className="mx-auto flex max-w-screen-xl items-center justify-between gap-4 p-2 lg:px-4">
         <a href="/" className="flex items-center space-x-3 rtl:space-x-reverse">
-          <Image
-            src={logo}
-            alt="StatBus Logo"
-            width={32}
-            height={32}
-            className="h-8"
-          />
+          <Image src={logo} alt="StatBus Logo" className="h-10 w-10" />
         </a>
         {session.data.session?.user && (
           <div className="flex-1 space-x-3 flex items-center justify-end">


### PR DESCRIPTION
**Issue:**
The login page shows full menu with actions only intended for authenticated users.

**Proposed Fix:**
- Navbar and footer actions such as command palette, link to search, link to reports are only available if there is a session.
  - To verify a session, the footer and navbar server components are now made async (because it needs to retrieve the supabase session information). To prevent navbar and footer from blocking page render, these components are now wrapped in separate `Suspense` boundaries. 