### PR TITLE
[ui] Import Command component from @/components and not cmdk

### DIFF
--- a/app/src/app/search/components/conditional-filter.tsx
+++ b/app/src/app/search/components/conditional-filter.tsx
@@ -5,7 +5,6 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
-import { Command } from "cmdk";
 import * as React from "react";
 import { useCallback, useState } from "react";
 import { Separator } from "@/components/ui/separator";
@@ -19,6 +18,7 @@ import {
 } from "@/components/ui/select";
 import { ConditionalValueBadge } from "@/app/search/components/conditional-value-badge";
 import { cn } from "@/lib/utils";
+import { Command } from "@/components/ui/command";
 
 interface ITableFilterCustomProps {
   title: string;

--- a/app/src/app/search/components/options-filter.tsx
+++ b/app/src/app/search/components/options-filter.tsx
@@ -5,8 +5,8 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
-import { Command } from "cmdk";
 import {
+  Command,
   CommandEmpty,
   CommandGroup,
   CommandInput,

--- a/app/src/app/search/components/search-bulk-action-button.tsx
+++ b/app/src/app/search/components/search-bulk-action-button.tsx
@@ -6,8 +6,8 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import { Settings, Trash } from "lucide-react";
-import { Command } from "cmdk";
 import {
+  Command,
   CommandEmpty,
   CommandGroup,
   CommandInput,

--- a/app/src/components/time-context-selector.tsx
+++ b/app/src/components/time-context-selector.tsx
@@ -7,8 +7,8 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import { cn } from "@/lib/utils";
-import { Command } from "cmdk";
 import {
+  Command,
   CommandEmpty,
   CommandGroup,
   CommandInput,


### PR DESCRIPTION
This PR corrects all imports of the `Command` component from `cmdk` to _Shadcn_ component `@/components/ui`. 