### PR TITLE
[ui] Reset pagination page number whenever any search filter change

### DIFF
--- a/app/src/app/search/search-filter-reducer.ts
+++ b/app/src/app/search/search-filter-reducer.ts
@@ -9,6 +9,7 @@ export function searchFilterReducer(
         ...state,
         queries: { ...state.queries, [name]: query },
         values: { ...state.values, [name]: values },
+        pagination: { ...state.pagination, pageNumber: 1 },
       };
     }
     case "reset_all":


### PR DESCRIPTION
### Current behavior
Whenever I update a search filter, the pagination is stuck on whatever was the previous selected page. If the new search filter yields fewer search results than before, this can result in an search result page even if there are search results on lower page numbers.

### Expected behavior
Whenever I update a search filter I expect the pagination to be reset to page 1

### Proposed Fix
Reset pagination page number when filter query is updated
