### PR TITLE
[ui] Fix unintended preservation of searchparams

### DIFF
--- a/app/src/components/statistical-unit-details-link-with-sub-path.tsx
+++ b/app/src/components/statistical-unit-details-link-with-sub-path.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { usePathname } from "next/navigation";
+import { usePathname, useSearchParams } from "next/navigation";
 import {
   StatisticalUnitDetailsLink,
   StatisticalUnitDetailsLinkProps,
@@ -14,7 +14,10 @@ export function StatisticalUnitDetailsLinkWithSubPath(
    * we want to go to /establishments/2/contact. */
 
   const pathname = usePathname();
+  const params = useSearchParams().toString();
   const path = pathname.split(/\d{1,10}\//)?.[1] ?? "";
 
-  return <StatisticalUnitDetailsLink {...props} sub_path={path} />;
+  return (
+    <StatisticalUnitDetailsLink {...props} sub_path={path} params={params} />
+  );
 }

--- a/app/src/components/statistical-unit-details-link.tsx
+++ b/app/src/components/statistical-unit-details-link.tsx
@@ -1,7 +1,6 @@
 import Link from "next/link";
 import { cn } from "@/lib/utils";
 import { ReactNode } from "react";
-import { useSearchParams } from "next/navigation";
 
 export interface StatisticalUnitDetailsLinkProps {
   readonly id: number;
@@ -13,6 +12,7 @@ export interface StatisticalUnitDetailsLinkProps {
   readonly children?: ReactNode;
   readonly className?: string;
   readonly sub_path?: string;
+  readonly params?: string;
 }
 
 export function StatisticalUnitDetailsLink({
@@ -21,6 +21,7 @@ export function StatisticalUnitDetailsLink({
   children,
   className,
   sub_path,
+  params,
 }: StatisticalUnitDetailsLinkProps) {
   const href = {
     enterprise_group: `/enterprise-groups/${id}`,
@@ -29,7 +30,6 @@ export function StatisticalUnitDetailsLink({
     establishment: `/establishments/${id}`,
   }[type];
 
-  const params = useSearchParams();
   const path = sub_path ? `${href}/${sub_path}` : href;
   const url = params ? `${path}?${params}` : path;
 


### PR DESCRIPTION
- Fix issue with searchparams like 'unit_type=enterprise' persisting in the URL when navigating from the search page